### PR TITLE
Feat/label component ignore text buf

### DIFF
--- a/packages/vrender-components/src/label/line.ts
+++ b/packages/vrender-components/src/label/line.ts
@@ -12,7 +12,8 @@ export class LineLabel extends LabelBase<LineLabelAttrs> {
       fontSize: 12,
       fill: '#000',
       textAlign: 'center',
-      textBaseline: 'middle'
+      textBaseline: 'middle',
+      boundsPadding: [-1, 0, -1, 0] // to ignore the textBound buf
     },
     position: 'end',
     offset: 6,

--- a/packages/vrender-components/src/label/rect.ts
+++ b/packages/vrender-components/src/label/rect.ts
@@ -11,7 +11,8 @@ export class RectLabel extends LabelBase<RectLabelAttrs> {
       fontSize: 12,
       fill: '#000',
       textAlign: 'center',
-      textBaseline: 'middle'
+      textBaseline: 'middle',
+      boundsPadding: [-1, 0, -1, 0] // to ignore the textBound buf
     },
     position: 'top',
     offset: 5,

--- a/packages/vrender-components/src/label/symbol.ts
+++ b/packages/vrender-components/src/label/symbol.ts
@@ -11,7 +11,8 @@ export class SymbolLabel extends LabelBase<SymbolLabelAttrs> {
       fontSize: 12,
       fill: '#000',
       textAlign: 'center',
-      textBaseline: 'middle'
+      textBaseline: 'middle',
+      boundsPadding: [-1, 0, -1, 0] // to ignore the textBound buf
     },
     position: 'top',
     offset: 5,

--- a/packages/vrender/src/graphic/text.ts
+++ b/packages/vrender/src/graphic/text.ts
@@ -101,19 +101,6 @@ export class Text extends Graphic<ITextGraphicAttribute> implements IText {
       this
     ) as AABBBounds;
 
-    this.clearUpdateBoundTag();
-    return bounds;
-  }
-  private updateAABBBounds(): AABBBounds {
-    const textTheme = getTheme(this).text;
-    const attribute = this.attribute;
-    const bounds = application.graphicService.updateTextAABBBounds(
-      attribute,
-      getTheme(this).text,
-      this._AABBBounds,
-      this
-    ) as AABBBounds;
-
     const { boundsPadding = textTheme.boundsPadding } = this.attribute;
     const paddingArray = parsePadding(boundsPadding);
     if (paddingArray) {
@@ -121,7 +108,6 @@ export class Text extends Graphic<ITextGraphicAttribute> implements IText {
     }
 
     this.clearUpdateBoundTag();
-
     return bounds;
   }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vrender/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
1. As text bound calculation will add 2 pixel buffer which is not necessary in label overlapping, one way to avoid the buf is to configure`boundsPadding` to a negative value;

2. fix `boundsPadding` attribute is not work in text graphic. 


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
