### PR TITLE
Fix/axis label auto limit

### DIFF
--- a/common/changes/@visactor/vrender-components/fix-axis-label-auto-limit_2023-07-24-14-34.json
+++ b/common/changes/@visactor/vrender-components/fix-axis-label-auto-limit_2023-07-24-14-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vrender-components",
+      "comment": "fix: fix the issue of maxLineWidth's value is negative",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vrender-components"
+}

--- a/packages/vrender-components/__tests__/browser/examples/axis-overlap.ts
+++ b/packages/vrender-components/__tests__/browser/examples/axis-overlap.ts
@@ -46,7 +46,7 @@ const axisBottom = new LineAxis({
     visible: true,
     space: 10,
     autoRotate: true,
-    autoRotateAngle: [0, 30, 60],
+    autoRotateAngle: [-45],
     autoHide: true,
     autoLimit: true,
     // dataFilter: data => {

--- a/packages/vrender-components/src/axis/overlap/auto-limit.ts
+++ b/packages/vrender-components/src/axis/overlap/auto-limit.ts
@@ -27,7 +27,7 @@ export function autoLimit(labels: IText[], config: LimitConfig) {
           : limitLength
         : limitLength / Math.sin(label.attribute.angle);
     label.setAttributes({
-      maxLineWidth: limitLabelLength,
+      maxLineWidth: Math.abs(limitLabelLength),
       ellipsis
     });
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vrender/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
