### PR TITLE
fix: fix wrapText line cut error

### DIFF
--- a/common/changes/@visactor/vrender-components/fix-wrap-text-line-cut_2023-08-16-02-59.json
+++ b/common/changes/@visactor/vrender-components/fix-wrap-text-line-cut_2023-08-16-02-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vrender-components",
+      "comment": "fix: fix wrapText line cut error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vrender-components"
+}

--- a/common/changes/@visactor/vrender/fix-wrap-text-line-cut_2023-08-16-02-59.json
+++ b/common/changes/@visactor/vrender/fix-wrap-text-line-cut_2023-08-16-02-59.json
@@ -1,10 +1,10 @@
 {
   "changes": [
     {
-      "packageName": "@visactor/vrender-components",
+      "packageName": "@visactor/vrender",
       "comment": "fix: fix wrapText line cut error",
       "type": "patch"
     }
   ],
-  "packageName": "@visactor/vrender-components"
+  "packageName": "@visactor/vrender"
 }

--- a/docs/demos/src/pages/wrap-text.ts
+++ b/docs/demos/src/pages/wrap-text.ts
@@ -1,7 +1,7 @@
-import { createGroup, createStage, createWrapText, global } from '@visactor/vrender';
+import { createGroup, createStage, createWrapText, vglobal } from '@visactor/vrender';
 import { addShapesToStage, colorPools } from '../utils';
 
-global.setEnv('browser');
+vglobal.setEnv('browser');
 
 export const page = () => {
   const shapes: any = [];
@@ -50,7 +50,7 @@ export const page = () => {
     "textBaseline": "top",
     // "width": 12,
     // "fontColor": "#333",
-    "maxLineWidth": 12,
+    "maxLineWidth": 6,
     "x": 200,
     "y": 200
   },

--- a/packages/vrender/src/graphic/wrap-text.ts
+++ b/packages/vrender/src/graphic/wrap-text.ts
@@ -76,6 +76,7 @@ export class WrapText extends Text {
       if (maxLineWidth > 0) {
         for (let i = 0; i < lines.length; i++) {
           const str = lines[i] as string;
+          let needCut = true;
           // // 测量当前行宽度
           // width = Math.min(
           //   layoutObj.textMeasure.measureTextWidth(str, layoutObj.textOptions),
@@ -110,6 +111,7 @@ export class WrapText extends Text {
               clip.str = '';
               clip.width = 0;
             }
+            needCut = false;
           }
 
           linesLayout.push({
@@ -118,7 +120,7 @@ export class WrapText extends Text {
           });
           if (clip.str.length === str.length) {
             // 不需要截断
-          } else {
+          } else if (needCut) {
             const newStr = str.substring(clip.str.length);
             lines.splice(i + 1, 0, newStr);
           }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vrender/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
