### PR TITLE
fix: wrapText support wordBreak

### DIFF
--- a/docs/demos/src/pages/wrap-text.ts
+++ b/docs/demos/src/pages/wrap-text.ts
@@ -1,7 +1,5 @@
-import { createGroup, createStage, createWrapText, global } from '@visactor/vrender';
+import { createGroup, createStage, createWrapText } from '@visactor/vrender';
 import { addShapesToStage, colorPools } from '../utils';
-
-global.setEnv('browser');
 
 export const page = () => {
   const shapes: any = [];
@@ -13,13 +11,23 @@ export const page = () => {
   group.createOrUpdateChild(
     'wrap-text',
     {
-      text: ['这是abc'],
-      x: 100,
-      y: 100,
-      fill: 'green',
+      fontFamily: 'sans-serif',
+      fontSize: 14,
+      fontWeight: null,
+      wordBreak: 'break-word',
+      fill: '#000',
       textAlign: 'left',
-      textBaseline: 'alphabetic',
-      maxLineWidth: 600
+      textBaseline: 'top',
+      lineHeight: 14,
+      ellipsis: '...',
+      text: ['back-end engineer'],
+      maxLineWidth: 93,
+      // autoWrapText: true,
+      heightLimit: -1,
+      pickable: false,
+      dx: 0,
+      x: 16,
+      y: 10
     },
     'wrapText'
   );
@@ -38,23 +46,24 @@ export const page = () => {
     'wrapText'
   );
 
-  group.createOrUpdateChild('text-error', {
-    "text": [
-      "饼图"
-    ],
-    "ellipsis": "...",
-    "fill": "#333",
-    "fontSize": 14,
-    "fontWeight": "bold",
-    "textAlign": "left",
-    "textBaseline": "top",
-    // "width": 12,
-    // "fontColor": "#333",
-    "maxLineWidth": 12,
-    "x": 200,
-    "y": 200
-  },
-  'wrapText');
+  group.createOrUpdateChild(
+    'text-error',
+    {
+      text: ['饼图'],
+      ellipsis: '...',
+      fill: '#333',
+      fontSize: 14,
+      fontWeight: 'bold',
+      textAlign: 'left',
+      textBaseline: 'top',
+      // "width": 12,
+      // "fontColor": "#333",
+      maxLineWidth: 12,
+      x: 200,
+      y: 200
+    },
+    'wrapText'
+  );
 
   shapes.push(group.children[0]);
   shapes.push(group.children[1]);
@@ -101,7 +110,7 @@ export const page = () => {
   //     text: ['多行自动换行高度限制多行多行'],
   //     maxLineWidth: 60,
   //     heightLimit: 50,
-  //     
+  //
   //     ellipsis: ''
   //   })
   // );

--- a/packages/vrender/src/graphic/index.ts
+++ b/packages/vrender/src/graphic/index.ts
@@ -17,6 +17,7 @@
 export * from './node-tree';
 export * from './circle';
 export * from './text';
+export * from './wrap-text';
 export * from './symbol';
 export * from './builtin-symbol';
 export * from './line';

--- a/packages/vrender/src/graphic/wrap-text.ts
+++ b/packages/vrender/src/graphic/wrap-text.ts
@@ -40,6 +40,7 @@ export class WrapText extends Text {
       maxLineWidth,
       stroke = textTheme.stroke,
       lineWidth = textTheme.lineWidth,
+      wordBreak = textTheme.wordBreak,
       // widthLimit,
       heightLimit = 0,
       lineClamp
@@ -85,7 +86,13 @@ export class WrapText extends Text {
           // 判断是否超过高度限制
           if (i === lineCountLimit - 1) {
             // 当前行为最后一行
-            const clip = layoutObj.textMeasure.clipTextWithSuffix(str, layoutObj.textOptions, maxLineWidth, ellipsis);
+            const clip = layoutObj.textMeasure.clipTextWithSuffix(
+              str,
+              layoutObj.textOptions,
+              maxLineWidth,
+              ellipsis,
+              wordBreak === 'break-word'
+            );
             linesLayout.push({
               str: clip.str,
               width: clip.width
@@ -94,14 +101,20 @@ export class WrapText extends Text {
           }
 
           // 测量截断位置
-          const clip = layoutObj.textMeasure.clipText(str, layoutObj.textOptions, maxLineWidth);
+          const clip = layoutObj.textMeasure.clipText(
+            str,
+            layoutObj.textOptions,
+            maxLineWidth,
+            wordBreak === 'break-word'
+          );
           if (str !== '' && clip.str === '') {
             if (ellipsis) {
               const clipEllipsis = layoutObj.textMeasure.clipTextWithSuffix(
                 str,
                 layoutObj.textOptions,
                 maxLineWidth,
-                ellipsis
+                ellipsis,
+                wordBreak === 'break-word'
               );
               clip.str = clipEllipsis.str ?? '';
               clip.width = clipEllipsis.width ?? 0;
@@ -143,7 +156,8 @@ export class WrapText extends Text {
             lines[i],
             layoutObj.textOptions,
             maxLineWidth,
-            ellipsis
+            ellipsis,
+            wordBreak === 'break-word'
           );
           linesLayout.push({
             str: clip.str,
@@ -154,7 +168,7 @@ export class WrapText extends Text {
         }
 
         text = lines[i] as string;
-        width = layoutObj.textMeasure.measureTextWidth(text, layoutObj.textOptions);
+        width = layoutObj.textMeasure.measureTextWidth(text, layoutObj.textOptions, wordBreak === 'break-word');
         lineWidth = Math.max(lineWidth, width);
         linesLayout.push({ str: text, width });
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vrender/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
