### PR TITLE
fix: fix arc stroke issue

### DIFF
--- a/common/changes/@visactor/vrender/fix-arc-stroke1_2023-09-18-12-59.json
+++ b/common/changes/@visactor/vrender/fix-arc-stroke1_2023-09-18-12-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vrender",
+      "comment": "fix: fix arc stroke issue",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vrender"
+}

--- a/packages/vrender/src/render/contributions/render/utils.ts
+++ b/packages/vrender/src/render/contributions/render/utils.ts
@@ -305,7 +305,6 @@ export function drawArcPath(
     let yore: number;
     let xirs: number;
     let yirs: number;
-
     if (maxInnerCornerRadius > epsilon || maxOuterCornerRadius > epsilon) {
       xore = outerRadius * cos(outerEndAngle);
       yore = outerRadius * sin(outerEndAngle);
@@ -403,7 +402,7 @@ export function drawArcPath(
         context.moveTo(cx + xors, cy + yors);
         context.arc(cx, cy, outerRadius, outerStartAngle, outerEndAngle, !clockwise);
       } else {
-        context.moveTo(cx + outerRadius * cos(outerEndAngle), cy + (yore ?? 0));
+        context.moveTo(cx + outerRadius * cos(outerEndAngle), cy + outerRadius * sin(outerEndAngle));
       }
     }
     // Is there no inner ring, and it’s a circular sector?


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vrender/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
