### PR TITLE
fix: fix `label.rotate: false` not work in arc inside label

### DIFF
--- a/common/changes/@visactor/vrender-components/fix-dsiable-arc-inside-label-rotate_2024-04-25-06-34.json
+++ b/common/changes/@visactor/vrender-components/fix-dsiable-arc-inside-label-rotate_2024-04-25-06-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vrender-components",
+      "comment": "fix: `label.rotate: false` not work in inside arc label ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vrender-components"
+}

--- a/packages/vrender-components/src/label/arc.ts
+++ b/packages/vrender-components/src/label/arc.ts
@@ -338,12 +338,14 @@ export class ArcLabel extends LabelBase<ArcLabelAttrs> {
         arc.labelVisible = false;
       }
 
-      arc.angle = attribute.textStyle?.angle ?? arc.middleAngle;
-      let offsetAngle = labelConfig.offsetAngle ?? 0;
-      if (['inside-inner', 'inside-outer'].includes(position as string)) {
-        offsetAngle += Math.PI / 2;
+      if (labelConfig.rotate !== false) {
+        arc.angle = attribute.textStyle?.angle ?? arc.middleAngle;
+        let offsetAngle = labelConfig.offsetAngle ?? 0;
+        if (['inside-inner', 'inside-outer'].includes(position as string)) {
+          offsetAngle += Math.PI / 2;
+        }
+        arc.angle += offsetAngle;
       }
-      arc.angle += offsetAngle;
     });
     return arcs;
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/vrender/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
Closing https://github.com/VisActor/VChart/issues/2578
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 🐞 Bugserver case id
6629fa40f134f700b55ae22d
<!-- paste the `fileid` field in the bugserver case url -->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
