### PR TITLE
Fix/tag richtext

### DIFF
--- a/common/changes/@visactor/vrender-components/fix-tag-richtext_2025-03-10-09-10.json
+++ b/common/changes/@visactor/vrender-components/fix-tag-richtext_2025-03-10-09-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vrender-components",
+      "comment": "fix: containerTextAlign and refX refY can not work when tag's label is rich text",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vrender-components"
+}

--- a/common/changes/@visactor/vrender-kits/fix-tag-richtext_2025-03-10-09-10.json
+++ b/common/changes/@visactor/vrender-kits/fix-tag-richtext_2025-03-10-09-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vrender-kits",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vrender-kits"
+}


### PR DESCRIPTION
修复 Tag 中 label 为富文本时，
1.  padding 配置后，文本渲染位置不对
2. containerTextAlign 在富文本中不生效的问题



### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

https://github.com/VisActor/VChart/issues/3790
### 🐞 Bugserver case id

<!-- paste the `fileid` field in the bugserver case url -->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
5. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
