### PR TITLE
perf: optimize shared state legend mount

### DIFF
--- a/packages/vrender-components/__tests__/electron/legend/discrete.test.ts
+++ b/packages/vrender-components/__tests__/electron/legend/discrete.test.ts
@@ -73,6 +73,72 @@ describe('DiscreteLegend', () => {
     // });
   });
 
+  it('should reuse static state definitions without coupling item selection', () => {
+    const legend = new DiscreteLegend({
+      select: true,
+      defaultSelected: ['A'],
+      item: {
+        shape: {
+          visible: false
+        },
+        label: {
+          style: {
+            fill: 'black'
+          },
+          state: {
+            selected: {
+              fill: 'red'
+            },
+            unSelected: {
+              fill: 'gray'
+            }
+          }
+        }
+      },
+      items: [
+        { label: 'A', shape: { fill: 'red' } },
+        { label: 'B', shape: { fill: 'blue' } }
+      ]
+    });
+
+    stage.defaultLayer.add(legend as unknown as IGraphic);
+    stage.render();
+
+    const items = ((legend as any)._itemsContainer.getChildren() as IGroup[]).slice(0, 2);
+    const labels = items.map(
+      item => (item.getChildren()[0] as IGroup).find(node => node.name === 'legendItemLabel', false) as IGraphic
+    );
+
+    expect(labels[0].states).toBe(labels[1].states);
+    expect((labels[0] as any).compiledStateDefinitions).toBe((labels[1] as any).compiledStateDefinitions);
+    expect(labels[0].attribute.fill).toBe('red');
+    expect(labels[1].attribute.fill).toBe('gray');
+
+    legend.setSelected(['B']);
+
+    expect(labels[0].attribute.fill).toBe('gray');
+    expect(labels[1].attribute.fill).toBe('red');
+
+    legend.setAttributes({
+      item: {
+        label: {
+          state: {
+            selected: { fill: 'green' },
+            unSelected: { fill: 'silver' }
+          }
+        }
+      }
+    } as any);
+
+    const rerenderedItems = ((legend as any)._itemsContainer.getChildren() as IGroup[]).slice(0, 2);
+    const rerenderedLabels = rerenderedItems.map(
+      item => (item.getChildren()[0] as IGroup).find(node => node.name === 'legendItemLabel', false) as IGraphic
+    );
+
+    expect(rerenderedLabels[0].attribute.fill).toBe('green');
+    expect(rerenderedLabels[1].attribute.fill).toBe('silver');
+  });
+
   it('should return its own width when its own width does not exceed maxWidth', () => {
     const legend = new DiscreteLegend({
       layout: 'vertical',

--- a/packages/vrender-components/src/legend/discrete/discrete.ts
+++ b/packages/vrender-components/src/legend/discrete/discrete.ts
@@ -33,6 +33,7 @@ import type {
   IRect
 } from '@visactor/vrender-core';
 // eslint-disable-next-line no-duplicate-imports
+import { StateDefinitionCompiler } from '@visactor/vrender-core';
 import { graphicCreator } from '../../util/graphic-creator';
 import { LegendBase } from '../base';
 import { Pager } from '../../pager';
@@ -61,6 +62,11 @@ import { loadDiscreteLegendComponent } from '../register';
 import { createTextGraphicByType } from '../../util';
 import { ScrollBar, type ScrollBarAttributes } from '../../scrollbar';
 import { commitUpdateAnimationTarget } from '../../animation/static-truth';
+
+type StateDefinitionsCacheEntry = {
+  definitions: Record<string, any>;
+  compiledDefinitions: Map<string, any>;
+};
 
 const DEFAULT_STATES = {
   [LegendStateValue.focus]: {},
@@ -105,6 +111,8 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
     startStops: ILinearGradient['stops'];
     endStops: ILinearGradient['stops'];
   };
+  // Weak keys avoid retaining caller-owned state definitions after a legend is released.
+  private _stateDefinitionsCache = new WeakMap<object, StateDefinitionsCacheEntry>();
 
   static defaultAttributes: Partial<DiscreteLegendAttrs> = {
     layout: 'horizontal',
@@ -200,6 +208,7 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
   }
 
   render() {
+    this._stateDefinitionsCache = new WeakMap<object, StateDefinitionsCacheEntry>();
     super.render();
     this._lastActiveItem = null;
   }
@@ -562,7 +571,14 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
         y: 0,
         ...backgroundStyle.style
       });
-      this._appendDataToShape(itemGroup, LEGEND_ELEMENT_NAME.item, item, itemGroup, backgroundStyle.state);
+      this._appendDataToShape(
+        itemGroup,
+        LEGEND_ELEMENT_NAME.item,
+        item,
+        itemGroup,
+        backgroundStyle.state,
+        backgroundStyle.reuseStateDefinitions
+      );
     }
     itemGroup.id = `${id ?? label}-${index}`;
 
@@ -607,7 +623,7 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
           (shapeStyle.state[key] as ISymbolGraphicAttribute).stroke = color as string;
         }
       });
-      this._appendDataToShape(itemShape, LEGEND_ELEMENT_NAME.itemShape, item, itemGroup, shapeStyle.state);
+      this._appendDataToShape(itemShape, LEGEND_ELEMENT_NAME.itemShape, item, itemGroup, shapeStyle.state, false);
 
       itemShape.addState(isSelected ? LegendStateValue.selected : LegendStateValue.unSelected);
       innerGroup.add(itemShape);
@@ -645,7 +661,14 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
 
     const labelShape = createTextGraphicByType(labelAttributes);
 
-    this._appendDataToShape(labelShape, LEGEND_ELEMENT_NAME.itemLabel, item, itemGroup, labelStyle.state);
+    this._appendDataToShape(
+      labelShape,
+      LEGEND_ELEMENT_NAME.itemLabel,
+      item,
+      itemGroup,
+      labelStyle.state,
+      labelStyle.reuseStateDefinitions
+    );
     labelShape.addState(isSelected ? LegendStateValue.selected : LegendStateValue.unSelected);
     innerGroup.add(labelShape);
     const labelSpace = get(labelAttr, 'space', DEFAULT_LABEL_SPACE);
@@ -665,7 +688,14 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
 
       const valueShape = createTextGraphicByType(valueAttributes);
 
-      this._appendDataToShape(valueShape, LEGEND_ELEMENT_NAME.itemValue, item, itemGroup, valueStyle.state);
+      this._appendDataToShape(
+        valueShape,
+        LEGEND_ELEMENT_NAME.itemValue,
+        item,
+        itemGroup,
+        valueStyle.state,
+        valueStyle.reuseStateDefinitions
+      );
       valueShape.addState(isSelected ? LegendStateValue.selected : LegendStateValue.unSelected);
 
       if (this._itemWidthByUser) {
@@ -1566,11 +1596,38 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
     return selectedData;
   }
 
-  private _appendDataToShape(shape: any, name: string, data: any, delegateShape: any, states: any = {}) {
+  private _appendDataToShape(
+    shape: any,
+    name: string,
+    data: any,
+    delegateShape: any,
+    states?: Record<string, any>,
+    reuseStateDefinitions: boolean = true
+  ) {
     shape.name = name;
     shape.data = data;
     shape.delegate = delegateShape;
-    shape.states = merge({}, DEFAULT_STATES, states);
+    if (!reuseStateDefinitions) {
+      shape.states = merge({}, DEFAULT_STATES, states);
+      return;
+    }
+
+    const source = states ?? DEFAULT_STATES;
+    const cached = this._stateDefinitionsCache.get(source);
+    if (cached) {
+      shape.states = cached.definitions;
+      (shape as any).setStateDefinitionsWithCompiled(cached.definitions, cached.compiledDefinitions);
+      return;
+    }
+
+    const definitions = states ? merge({}, DEFAULT_STATES, states) : DEFAULT_STATES;
+    const entry = {
+      definitions,
+      compiledDefinitions: new StateDefinitionCompiler().compile(definitions)
+    };
+    this._stateDefinitionsCache.set(source, entry);
+    shape.states = entry.definitions;
+    (shape as any).setStateDefinitionsWithCompiled(entry.definitions, entry.compiledDefinitions);
   }
 
   private _dispatchLegendEvent(eventName: string, legendItem: any, event: FederatedPointerEvent) {
@@ -1609,23 +1666,28 @@ export class DiscreteLegend extends LegendBase<DiscreteLegendAttrs> {
     }
 
     if (config.state) {
-      newConfig.state = {};
-
-      Object.keys(config.state).forEach(key => {
-        if (config.state[key]) {
-          if (isFunction(config.state[key])) {
-            newConfig.state[key] = config.state[key](item, isSelected, index, items);
-          } else {
-            newConfig.state[key] = config.state[key];
+      const stateKeys = Object.keys(config.state);
+      const hasStateFunction = stateKeys.some(key => isFunction(config.state[key]));
+      newConfig.reuseStateDefinitions = !hasStateFunction;
+      if (!hasStateFunction) {
+        newConfig.state = config.state;
+      } else {
+        newConfig.state = {};
+        stateKeys.forEach(key => {
+          if (config.state[key]) {
+            newConfig.state[key] = isFunction(config.state[key])
+              ? config.state[key](item, isSelected, index, items)
+              : config.state[key];
           }
-        }
-      });
+        });
+      }
     }
 
     return newConfig;
   }
 
   release(): void {
+    this._stateDefinitionsCache = new WeakMap<object, StateDefinitionsCacheEntry>();
     super.release();
     this.removeAllEventListeners();
   }

--- a/packages/vrender-core/__tests__/unit/graphic/graphic-state.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/graphic-state.test.ts
@@ -255,6 +255,38 @@ describe('Graphic useStates', () => {
     expect(graphic.currentStates).toEqual(['hover']);
   });
 
+  test('should retain an empty state without submitting attribute updates', () => {
+    const graphics = Array.from({ length: 100 }, createGraphic);
+    const onAttributeUpdate = jest.fn();
+    const afterStateUpdate = jest.fn();
+
+    graphics[0].addEventListener('afterStateUpdate', afterStateUpdate as any);
+
+    graphics.forEach(graphic => {
+      graphic.states = { selected: {} } as any;
+      jest.spyOn(graphic as any, 'onAttributeUpdate').mockImplementation(onAttributeUpdate);
+      graphic.addState('selected', false, false);
+    });
+
+    graphics.forEach(graphic => {
+      expect(graphic.currentStates).toEqual(['selected']);
+      expect(graphic.attribute).toBe((graphic as any).baseAttributes);
+      expect(graphic.resolvedStatePatch).toEqual({});
+    });
+    expect(onAttributeUpdate).not.toHaveBeenCalled();
+    expect(afterStateUpdate).toHaveBeenCalledTimes(1);
+
+    graphics.forEach(graphic => graphic.clearStates(false));
+
+    graphics.forEach(graphic => {
+      expect(graphic.currentStates).toEqual([]);
+      expect(graphic.attribute).toBe((graphic as any).baseAttributes);
+      expect(graphic.resolvedStatePatch).toBeUndefined();
+    });
+    expect(onAttributeUpdate).not.toHaveBeenCalled();
+    expect(afterStateUpdate).toHaveBeenCalledTimes(2);
+  });
+
   test('should emit beforeStateUpdate with previous and next state info', () => {
     const graphic = createGraphic();
     graphic.states = {

--- a/packages/vrender-core/__tests__/unit/graphic/graphic-state.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/graphic-state.test.ts
@@ -1,7 +1,12 @@
 import { createRect } from '../../../src/graphic/rect';
 import { AttributeUpdateType } from '../../../src/common/enums';
+import { StateDefinitionCompiler } from '../../../src/graphic/state/state-definition-compiler';
 
 describe('Graphic useStates', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const createGraphic = () => {
     const graphic = createRect({
       x: 0,
@@ -49,6 +54,50 @@ describe('Graphic useStates', () => {
       opacity: 1
     });
     expect(graphic.normalAttrs).toEqual((graphic as any).baseAttributes);
+  });
+
+  test('should reuse compiled local definitions for graphics with the same state source', () => {
+    const states = {
+      selected: {
+        fill: 'red'
+      }
+    } as any;
+    const first = createGraphic();
+    const second = createGraphic();
+    const compile = jest.spyOn(StateDefinitionCompiler.prototype, 'compile');
+    const compiledDefinitions = new StateDefinitionCompiler().compile(states);
+    (first as any).setStateDefinitionsWithCompiled(states, compiledDefinitions);
+    (second as any).setStateDefinitionsWithCompiled(states, compiledDefinitions);
+
+    first.useStates(['selected'], false);
+    second.useStates(['selected'], false);
+
+    expect(compile).toHaveBeenCalledTimes(1);
+    expect(first.attribute.fill).toBe('red');
+    expect(second.attribute.fill).toBe('red');
+
+    first.useStates([], false);
+
+    expect(first.attribute.fill).toBe('blue');
+    expect(second.attribute.fill).toBe('red');
+  });
+
+  test('should compile local definitions per graphic without a precompiled definition', () => {
+    const states = {
+      selected: {
+        fill: 'red'
+      }
+    } as any;
+    const first = createGraphic();
+    const second = createGraphic();
+    first.states = states;
+    second.states = states;
+    const compile = jest.spyOn(StateDefinitionCompiler.prototype, 'compile');
+
+    first.useStates(['selected'], false);
+    second.useStates(['selected'], false);
+
+    expect(compile).toHaveBeenCalledTimes(2);
   });
 
   test('should sync target states through a single optimized call', () => {

--- a/packages/vrender-core/__tests__/unit/graphic/shared-state-batch-mount.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/shared-state-batch-mount.test.ts
@@ -1,0 +1,91 @@
+import { Group, createGroup } from '../../../src/graphic/group';
+import { createRect } from '../../../src/graphic/rect';
+import { createSharedStateTestStage } from './shared-state-test-utils';
+
+describe('shared state batch mount', () => {
+  test('should preserve custom parent-tree synchronization hooks', () => {
+    const stage = createSharedStateTestStage();
+    const group = createGroup({});
+    const inheritedHandler = group.onParentSharedStateTreeChanged;
+    const customHandler = jest.fn((nextStage, nextLayer, nextScope) => {
+      inheritedHandler.call(group, nextStage, nextLayer, nextScope);
+    });
+    group.onParentSharedStateTreeChanged = customHandler;
+
+    stage.appendChild(group);
+
+    expect(customHandler).toHaveBeenCalledTimes(1);
+    expect(group.stage).toBe(stage);
+  });
+
+  test('should bind a detached multi-level subtree once while preserving inherited states and later tree edits', () => {
+    const stage = createSharedStateTestStage();
+    const stateScope = createGroup({});
+    const itemsContainer = createGroup({});
+    const stateDefinitions = {
+      selected: { fill: 'red', opacity: 0.5 }
+    };
+    const itemGroups = [] as ReturnType<typeof createGroup>[];
+    const itemShapes = [] as ReturnType<typeof createRect>[];
+
+    (stateScope as any).sharedStateDefinitions = stateDefinitions;
+    stateScope.appendChild(itemsContainer);
+
+    for (let index = 0; index < 100; index++) {
+      const itemGroup = createGroup({});
+      const contentGroup = createGroup({});
+      const shape = createRect({ x: index, y: 0, width: 1, height: 1, fill: 'black', opacity: 1 });
+
+      shape.states = { selected: { fill: 'local-selected' } };
+      itemGroup.currentStates = ['selected'];
+      shape.currentStates = ['selected'];
+      contentGroup.appendChild(shape);
+      itemGroup.appendChild(contentGroup);
+      itemsContainer.appendChild(itemGroup);
+      itemGroups.push(itemGroup);
+      itemShapes.push(shape);
+    }
+
+    const syncChildSharedStateTreeBinding = jest.spyOn(Group.prototype as any, 'syncChildSharedStateTreeBinding');
+    const onParentSharedStateTreeChanged = jest.spyOn(Group.prototype, 'onParentSharedStateTreeChanged');
+
+    stage.appendChild(stateScope);
+    itemShapes[0].refreshSharedStateBeforeRender();
+
+    expect(syncChildSharedStateTreeBinding).toHaveBeenCalledTimes(1);
+    expect(onParentSharedStateTreeChanged).not.toHaveBeenCalled();
+    expect((itemShapes[0] as any).boundSharedStateScope).toBe((stateScope as any).sharedStateScope);
+    expect(itemShapes[0].attribute.fill).toBe('red');
+    expect(itemShapes[0].attribute.opacity).toBe(0.5);
+
+    (stateScope as any).sharedStateDefinitions = {
+      selected: { fill: 'green', opacity: 0.75 }
+    };
+    itemShapes[0].refreshSharedStateBeforeRender();
+
+    expect(itemShapes[0].attribute.fill).toBe('green');
+    expect(itemShapes[0].attribute.opacity).toBe(0.75);
+
+    const addedItem = createGroup({});
+    const addedContent = createGroup({});
+    const addedShape = createRect({ x: 101, y: 0, width: 1, height: 1, fill: 'black', opacity: 1 });
+    addedShape.states = { selected: { fill: 'local-selected' } };
+    addedItem.currentStates = ['selected'];
+    addedShape.currentStates = ['selected'];
+    addedContent.appendChild(addedShape);
+    addedItem.appendChild(addedContent);
+
+    itemsContainer.appendChild(addedItem);
+    addedShape.refreshSharedStateBeforeRender();
+
+    expect((addedShape as any).boundSharedStateScope).toBe((stateScope as any).sharedStateScope);
+    expect(addedShape.attribute.fill).toBe('green');
+    expect(addedShape.attribute.opacity).toBe(0.75);
+
+    itemsContainer.removeChild(itemGroups[0]);
+
+    expect(itemGroups[0].stage).toBeNull();
+    expect(itemShapes[0].stage).toBeNull();
+    expect((itemShapes[0] as any).boundSharedStateScope).toBeUndefined();
+  });
+});

--- a/packages/vrender-core/__tests__/unit/graphic/shared-state-refresh.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/shared-state-refresh.test.ts
@@ -3,6 +3,25 @@ import { createGroup } from '../../../src/graphic/group';
 import { createSharedStateTestStage } from './shared-state-test-utils';
 
 describe('shared state refresh contract', () => {
+  test('should refresh an active empty state when its shared definition gains attrs', () => {
+    const stage = createSharedStateTestStage();
+    const group = createGroup({});
+    const rect = createRect({ x: 0, y: 0, width: 10, height: 10, fill: 'black' });
+
+    (group as any).sharedStateDefinitions = { selected: {} };
+    stage.appendChild(group);
+    group.appendChild(rect);
+
+    rect.addState('selected', false, false);
+    expect(rect.attribute).toBe((rect as any).baseAttributes);
+
+    (group as any).sharedStateDefinitions = { selected: { fill: 'red' } };
+    stage.hooks.beforeRender.call(stage);
+
+    expect(rect.currentStates).toEqual(['selected']);
+    expect(rect.attribute.fill).toBe('red');
+  });
+
   test('should refresh active descendants before next render when group shared definitions change', () => {
     const stage = createSharedStateTestStage();
     const outer = createGroup({});

--- a/packages/vrender-core/src/graphic/graphic.ts
+++ b/packages/vrender-core/src/graphic/graphic.ts
@@ -2298,6 +2298,20 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     return true;
   }
 
+  protected hasStatePatch(patch?: Partial<T>): boolean {
+    if (!patch) {
+      return false;
+    }
+
+    for (const key in patch) {
+      if (Object.prototype.hasOwnProperty.call(patch, key)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   protected commitSameStatePatchRefresh(
     states: string[],
     hasAnimation?: boolean,
@@ -2466,6 +2480,10 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     this.resolvedStatePatch = undefined;
     this.sharedStateDirty = false;
     this.clearSharedStateActiveRegistrations();
+    if (!this.attributeMayContainTransientAttrs && !this.hasStatePatch(previousResolvedStatePatch)) {
+      this.emitStateUpdateEvent();
+      return;
+    }
     if (hasAnimation) {
       this._syncFinalAttributeFromStaticTruth();
       const removedStateAnimationAttrs = this.buildRemovedStateAnimationAttrs(
@@ -2572,6 +2590,14 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     this.resolvedStatePatch = resolvedStateAttrs;
     this.sharedStateDirty = false;
     this.syncSharedStateActiveRegistrations();
+    if (
+      !this.attributeMayContainTransientAttrs &&
+      !this.hasStatePatch(previousResolvedStatePatch) &&
+      !this.hasStatePatch(resolvedStateAttrs)
+    ) {
+      this.emitStateUpdateEvent();
+      return;
+    }
     if (hasAnimation) {
       this._syncFinalAttributeFromStaticTruth();
       const removedStateAnimationAttrs = this.buildRemovedStateAnimationAttrs(

--- a/packages/vrender-core/src/graphic/graphic.ts
+++ b/packages/vrender-core/src/graphic/graphic.ts
@@ -530,8 +530,10 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     return this.stage?.rootSharedStateScope as SharedStateScope<Record<string, any>> | undefined;
   }
 
-  protected syncSharedStateScopeBindingFromTree(markDirty: boolean = true): boolean {
-    const nextScope = this.resolveBoundSharedStateScope();
+  protected syncSharedStateScopeBinding(
+    nextScope: SharedStateScope<T> | SharedStateScope<Record<string, any>> | undefined,
+    markDirty: boolean = true
+  ): boolean {
     if (this.boundSharedStateScope === nextScope) {
       this.syncSharedStateActiveRegistrations();
       return false;
@@ -552,7 +554,21 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     return true;
   }
 
-  protected syncSharedStateScopeBindingOnTreeChange(markDirty: boolean = true): boolean {
+  protected syncSharedStateScopeBindingFromTree(
+    markDirty: boolean = true,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): boolean {
+    const nextScope =
+      inheritedSharedStateScope === undefined
+        ? this.resolveBoundSharedStateScope()
+        : inheritedSharedStateScope ?? undefined;
+    return this.syncSharedStateScopeBinding(nextScope, markDirty);
+  }
+
+  protected syncSharedStateScopeBindingOnTreeChange(
+    markDirty: boolean = true,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): boolean {
     if (
       !this.currentStates?.length &&
       !this.boundSharedStateScope &&
@@ -562,7 +578,7 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       return false;
     }
 
-    return this.syncSharedStateScopeBindingFromTree(markDirty);
+    return this.syncSharedStateScopeBindingFromTree(markDirty, inheritedSharedStateScope);
   }
 
   protected syncSharedStateActiveRegistrations(): void {
@@ -579,6 +595,10 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       return;
     }
 
+    if (previousScopes?.size && this.isSharedStateScopeChainRegistered(previousScopes)) {
+      return;
+    }
+
     const nextScopes = new Set(collectSharedStateScopeChain(this.boundSharedStateScope));
 
     previousScopes?.forEach(scope => {
@@ -592,6 +612,21 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     });
 
     this.registeredActiveScopes = nextScopes;
+  }
+
+  protected isSharedStateScopeChainRegistered(previousScopes: Set<SharedStateScope<T>>): boolean {
+    let scope = this.boundSharedStateScope;
+    let scopeCount = 0;
+
+    while (scope) {
+      if (!previousScopes.has(scope)) {
+        return false;
+      }
+      scopeCount += 1;
+      scope = scope.parentScope as SharedStateScope<T> | undefined;
+    }
+
+    return scopeCount === previousScopes.size;
   }
 
   protected clearSharedStateActiveRegistrations(): void {
@@ -611,13 +646,17 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     scheduleStageSharedStateRefresh(this.stage);
   }
 
-  onParentSharedStateTreeChanged(stage?: IStage, layer?: ILayer): void {
+  onParentSharedStateTreeChanged(
+    stage?: IStage,
+    layer?: ILayer,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): void {
     if (this.stage !== stage || this.layer !== layer) {
-      this.setStage(stage, layer);
+      this.setStage(stage, layer, inheritedSharedStateScope);
       return;
     }
 
-    this.syncSharedStateScopeBindingOnTreeChange();
+    this.syncSharedStateScopeBindingOnTreeChange(true, inheritedSharedStateScope);
   }
 
   refreshSharedStateBeforeRender(): void {
@@ -2025,6 +2064,20 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     return this.states?.[stateName];
   }
 
+  /** @internal Used by bulk component construction to avoid recompiling known-static definitions. */
+  setStateDefinitionsWithCompiled(
+    definitions: StateDefinitionsInput<T>,
+    compiledDefinitions: Map<string, CompiledStateDefinition<T>>
+  ): void {
+    this.states = definitions;
+    if (this.localStateDefinitionsSource !== definitions) {
+      this.localStateDefinitionsSource = definitions;
+      this.localStateDefinitionsVersion = (this.localStateDefinitionsVersion ?? 0) + 1;
+    }
+    this.compiledStateDefinitions = compiledDefinitions;
+    this.compiledStateDefinitionsCacheKey = `local:${this.localStateDefinitionsVersion}`;
+  }
+
   protected getStateResolveBaseAttrs(): Partial<T> {
     return (this.baseAttributes ?? this.attribute) as Partial<T>;
   }
@@ -2766,7 +2819,7 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     }
   }
 
-  setStage(stage?: IStage, layer?: ILayer) {
+  setStage(stage?: IStage, layer?: ILayer, inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null) {
     const graphicService = stage?.graphicService ?? this.stage?.graphicService ?? application.graphicService;
     const previousStage = this.stage;
     if (this.stage !== stage || this.layer !== layer) {
@@ -2778,7 +2831,7 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
         this.registeredActiveScopes?.size ||
         this.sharedStateDirty
       ) {
-        this.syncSharedStateScopeBindingOnTreeChange(true);
+        this.syncSharedStateScopeBindingOnTreeChange(true, inheritedSharedStateScope);
       }
       this.setStageToShadowRoot(stage, layer);
       if (this.mayHaveTrackedAnimates() && this.hasAnyTrackedAnimate()) {
@@ -2833,7 +2886,7 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       this.registeredActiveScopes?.size ||
       this.sharedStateDirty
     ) {
-      this.syncSharedStateScopeBindingOnTreeChange(true);
+      this.syncSharedStateScopeBindingOnTreeChange(true, inheritedSharedStateScope);
     }
   }
 

--- a/packages/vrender-core/src/graphic/group.ts
+++ b/packages/vrender-core/src/graphic/group.ts
@@ -355,7 +355,7 @@ export class Group extends Graphic<IGroupGraphicAttribute> implements IGroup {
     this.addUpdateBoundTag();
   }
 
-  setStage(stage?: IStage, layer?: ILayer) {
+  setStage(stage?: IStage, layer?: ILayer, inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null) {
     const graphicService = stage?.graphicService ?? this.stage?.graphicService ?? application.graphicService;
     const needsSharedStateTreeSync =
       this.hasSharedStateDefinitions() ||
@@ -369,12 +369,12 @@ export class Group extends Graphic<IGroupGraphicAttribute> implements IGroup {
       this.layer = layer;
       if (needsSharedStateTreeSync) {
         this.ensureSharedStateScopeBound();
-        this.syncSharedStateScopeBindingOnTreeChange(true);
+        this.syncSharedStateScopeBindingOnTreeChange(true, inheritedSharedStateScope);
       }
       this.setStageToShadowRoot(stage, layer);
       this._onSetStage && this._onSetStage(this, stage, layer);
       graphicService?.onSetStage?.(this, stage);
-      this.notifyChildrenSharedStateTreeChanged();
+      this.notifyChildrenSharedStateTreeChanged(inheritedSharedStateScope);
       return;
     }
 
@@ -384,10 +384,10 @@ export class Group extends Graphic<IGroupGraphicAttribute> implements IGroup {
     }
     if (needsSharedStateTreeSync) {
       this.ensureSharedStateScopeBound();
-      this.syncSharedStateScopeBindingOnTreeChange(true);
-      this.notifyChildrenSharedStateTreeChanged();
+      this.syncSharedStateScopeBindingOnTreeChange(true, inheritedSharedStateScope);
+      this.notifyChildrenSharedStateTreeChanged(inheritedSharedStateScope);
     } else if (layerChanged) {
-      this.notifyChildrenSharedStateTreeChanged();
+      this.notifyChildrenSharedStateTreeChanged(inheritedSharedStateScope);
     }
   }
   /**
@@ -520,25 +520,67 @@ export class Group extends Graphic<IGroupGraphicAttribute> implements IGroup {
     return !!this._sharedStateDefinitions && Object.keys(this._sharedStateDefinitions).length > 0;
   }
 
-  protected notifyChildrenSharedStateTreeChanged(): void {
+  protected resolveChildSharedStateScope(
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): SharedStateScope<Record<string, any>> | null {
+    if (this.sharedStateScope) {
+      return this.sharedStateScope;
+    }
+    if (inheritedSharedStateScope !== undefined) {
+      return inheritedSharedStateScope;
+    }
+    return this.resolveBoundSharedStateScope() ?? null;
+  }
+
+  protected notifyChildrenSharedStateTreeChanged(
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): void {
+    const childSharedStateScope = this.resolveChildSharedStateScope(inheritedSharedStateScope);
     this.forEachChildren(item => {
-      this.syncChildSharedStateTreeBinding(item);
+      this.setStageToChild(item, childSharedStateScope);
     });
   }
 
-  protected syncChildSharedStateTreeBinding(child: INode): void {
-    child.onParentSharedStateTreeChanged(this.stage, this.layer);
+  protected setStageToChild(
+    child: INode,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): void {
+    const graphic = child as IGraphic;
+    if (
+      typeof graphic.setStage === 'function' &&
+      (child.onParentSharedStateTreeChanged === Graphic.prototype.onParentSharedStateTreeChanged ||
+        child.onParentSharedStateTreeChanged === Group.prototype.onParentSharedStateTreeChanged) &&
+      (graphic.stage !== this.stage || graphic.layer !== this.layer)
+    ) {
+      graphic.setStage(this.stage, this.layer, inheritedSharedStateScope);
+      return;
+    }
+    child.onParentSharedStateTreeChanged(this.stage, this.layer, inheritedSharedStateScope);
   }
 
-  onParentSharedStateTreeChanged(stage?: IStage, layer?: ILayer): void {
+  protected syncChildSharedStateTreeBinding(
+    child: INode,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): void {
+    if (inheritedSharedStateScope === undefined) {
+      inheritedSharedStateScope = this.resolveChildSharedStateScope();
+    }
+    this.setStageToChild(child, inheritedSharedStateScope);
+  }
+
+  onParentSharedStateTreeChanged(
+    stage?: IStage,
+    layer?: ILayer,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): void {
     if (this.stage !== stage || this.layer !== layer) {
-      this.setStage(stage, layer);
+      this.setStage(stage, layer, inheritedSharedStateScope);
       return;
     }
 
     this.ensureSharedStateScopeBound();
-    this.syncSharedStateScopeBindingOnTreeChange(!!this.currentStates?.length);
-    this.notifyChildrenSharedStateTreeChanged();
+    this.syncSharedStateScopeBindingOnTreeChange(!!this.currentStates?.length, inheritedSharedStateScope);
+    this.notifyChildrenSharedStateTreeChanged(inheritedSharedStateScope);
   }
 }
 

--- a/packages/vrender-core/src/graphic/node-tree.ts
+++ b/packages/vrender-core/src/graphic/node-tree.ts
@@ -1,6 +1,7 @@
 import { EventEmitter, Logger, isBoolean, isFunction, isObject, type Dict, type LooseFunction } from '@visactor/vutils';
 import { Generator } from '../common/generator';
 import type { ILayer, INode, IGroup, IStage } from '../interface';
+import type { SharedStateScope } from './state/shared-state-scope';
 
 export class Node extends EventEmitter<any, any> implements INode {
   parent: any;
@@ -59,7 +60,11 @@ export class Node extends EventEmitter<any, any> implements INode {
     this._count = 1;
   }
 
-  onParentSharedStateTreeChanged(_stage?: IStage, _layer?: ILayer): void {
+  onParentSharedStateTreeChanged(
+    _stage?: IStage,
+    _layer?: ILayer,
+    _inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ): void {
     return;
   }
 

--- a/packages/vrender-core/src/graphic/richtext.ts
+++ b/packages/vrender-core/src/graphic/richtext.ts
@@ -27,6 +27,7 @@ import { RichTextIcon } from './richtext/icon';
 import type { FederatedMouseEvent } from '../event';
 import { application } from '../application';
 import { RICHTEXT_NUMBER_TYPE } from './constants';
+import type { SharedStateScope } from './state/shared-state-scope';
 
 let supportIntl = false;
 try {
@@ -618,8 +619,8 @@ export class RichText extends Graphic<IRichTextGraphicAttribute> implements IRic
     return new RichText({ ...this.attribute });
   }
 
-  setStage(stage?: IStage, layer?: ILayer) {
-    super.setStage(stage, layer);
+  setStage(stage?: IStage, layer?: ILayer, inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null) {
+    super.setStage(stage, layer, inheritedSharedStateScope);
     const frameCache = this.getFrameCache();
     // for (let i = 0; i < frameCache.icons.length; i++) {
     //   const icon = frameCache.icons[i];

--- a/packages/vrender-core/src/interface/graphic.ts
+++ b/packages/vrender-core/src/interface/graphic.ts
@@ -853,7 +853,11 @@ export interface IGraphic<T extends Partial<IGraphicAttribute> = Partial<IGraphi
 
   setAttribute: (key: string, value: any, forceUpdateTag?: boolean, context?: ISetAttributeContext) => void;
 
-  setStage: (stage?: IStage, layer?: ILayer) => void;
+  setStage: (
+    stage?: IStage,
+    layer?: ILayer,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ) => void;
   detachStageForRelease: () => void;
   onSetStage: (cb: (g: IGraphic, stage: IStage) => void) => void;
 

--- a/packages/vrender-core/src/interface/node-tree.ts
+++ b/packages/vrender-core/src/interface/node-tree.ts
@@ -1,6 +1,7 @@
 import type { IEventElement, Releaseable } from './common';
 import type { ILayer } from './layer';
 import type { IStage } from './stage';
+import type { SharedStateScope } from '../graphic/state/shared-state-scope';
 
 export interface INode extends Releaseable, IEventElement {
   _prev?: INode;
@@ -69,7 +70,11 @@ export interface INode extends Releaseable, IEventElement {
   /**
    * Rebinds stage/layer derived state when this node is attached to a different parent tree.
    */
-  onParentSharedStateTreeChanged: (stage?: IStage, layer?: ILayer) => void;
+  onParentSharedStateTreeChanged: (
+    stage?: IStage,
+    layer?: ILayer,
+    inheritedSharedStateScope?: SharedStateScope<Record<string, any>> | null
+  ) => void;
   /**
    * 从当前节点的父节点删除当前节点
    */


### PR DESCRIPTION
## Summary

- Batch inherited shared-state scope resolution while mounting a detached graphic subtree, avoiding repeated recursive scope binding.
- Preserve custom parent-tree synchronization hooks and subsequent add/remove-child behavior.
- Compile static `DiscreteLegend` state definitions once per render and reuse the compiled definitions across compatible item text graphics.
- Scope the legend cache to one render and reset it on rerender/release, so it does not retain caller-owned state definitions.

## Root cause

A 100-category legend creates many item groups and child graphics. During first mount, each append repeatedly resolved and synchronized the same shared-state scope; static selected/unSelected definitions were also compiled repeatedly per legend item.

## Performance

For the VChart `pie.small.100` case, warmed Chrome traces show a median initial render of approximately **37–38 ms**, compared with **46.906 ms** before the Core optimization (about **19–21%** lower).

## Validation

- `packages/vrender-core`: targeted state and batch-mount tests (29 passing).
- `packages/vrender-components`: `DiscreteLegend` tests (5 passing).
- `rush compile -t @visactor/vrender-components`.
- Pre-push `rush test --only tag:package` (all package test operations passed).
