### PR TITLE
fix(lynx): prefer native animation frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ docs/public/documents
 spec-types
 *.tsbuildinfo
 .omx/
+.worktrees/

--- a/docs/superpowers/plans/2026-07-24-lynx-native-raf.md
+++ b/docs/superpowers/plans/2026-07-24-lynx-native-raf.md
@@ -1,0 +1,199 @@
+# Lynx Native RAF Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Lynx environment prefer the host's native animation-frame scheduler while preserving the existing timeout-backed fallback.
+
+**Architecture:** Select and bind one request/cancel scheduler pair during `LynxEnvContribution.configure()`. The animation hot path reads stable cached functions, and incomplete native capability falls back atomically to `rafBasedSto`.
+
+**Tech Stack:** TypeScript 4.9, Jest 26, Rush
+
+## Global Constraints
+
+- Native `requestAnimationFrame` and `cancelAnimationFrame` must be used only when both are functions.
+- Native methods must retain the Lynx runtime as their `this` receiver.
+- Missing or incomplete native capability must preserve the existing `rafBasedSto` behavior.
+- Do not change ticker semantics or non-Lynx environments.
+- Capability selection must stay out of the per-frame animation path.
+
+---
+
+### Task 1: Select the Lynx animation-frame scheduler pair
+
+**Files:**
+- Modify: `packages/vrender-kits/__tests__/unit/lynx-window-event.test.ts`
+- Modify: `packages/vrender-kits/src/env/contributions/lynx-contribution.ts`
+
+**Interfaces:**
+- Consumes: `LynxEnvContribution.configure(service, params)`, `rafBasedSto.call(callback)`, and `rafBasedSto.clear(handle)`.
+- Produces: `getRequestAnimationFrame(): (callback: FrameRequestCallback) => number` and `getCancelAnimationFrame(): (handle: number) => void`, backed by one scheduler pair selected during configuration.
+
+- [ ] **Step 1: Add focused scheduler tests**
+
+Add tests inside the existing `describe('lynx window event contribution', ...)` block:
+
+```ts
+test('uses the complete native lynx animation frame scheduler pair', () => {
+  const env = new LynxEnvContribution();
+  const service = {
+    env: 'lynx',
+    setActiveEnvContribution: jest.fn()
+  };
+  let requestReceiver: unknown;
+  let cancelReceiver: unknown;
+  let scheduledCallback: FrameRequestCallback;
+  let cancelledHandle: number;
+  const runtime = {
+    requestAnimationFrame(this: unknown, callback: FrameRequestCallback) {
+      requestReceiver = this;
+      scheduledCallback = callback;
+      return 17;
+    },
+    cancelAnimationFrame(this: unknown, handle: number) {
+      cancelReceiver = this;
+      cancelledHandle = handle;
+    }
+  };
+  const callback = jest.fn();
+
+  env.configure(service as any, { lynx: runtime });
+
+  expect(env.getRequestAnimationFrame()(callback)).toBe(17);
+  env.getCancelAnimationFrame()(17);
+
+  expect(requestReceiver).toBe(runtime);
+  expect(cancelReceiver).toBe(runtime);
+  expect(scheduledCallback).toBe(callback);
+  expect(cancelledHandle).toBe(17);
+});
+
+test('falls back as a pair when the native lynx scheduler is incomplete', () => {
+  jest.useFakeTimers();
+  try {
+    const env = new LynxEnvContribution();
+    const service = {
+      env: 'lynx',
+      setActiveEnvContribution: jest.fn()
+    };
+    const nativeRequest = jest.fn(() => 17);
+    const callback = jest.fn();
+
+    env.configure(service as any, {
+      lynx: {
+        requestAnimationFrame: nativeRequest
+      }
+    });
+
+    const handle = env.getRequestAnimationFrame()(callback);
+    env.getCancelAnimationFrame()(handle);
+    jest.runOnlyPendingTimers();
+
+    expect(nativeRequest).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  } finally {
+    jest.useRealTimers();
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cd packages/vrender-kits
+rushx test -- --runInBand __tests__/unit/lynx-window-event.test.ts
+```
+
+Expected: the native scheduler test fails because `getRequestAnimationFrame()` still schedules through `rafBasedSto`; the incomplete-scheduler fallback test passes.
+
+- [ ] **Step 3: Implement scheduler selection**
+
+Extend `LynxRuntime`:
+
+```ts
+requestAnimationFrame: (callback: FrameRequestCallback) => number;
+cancelAnimationFrame: (handle: number) => void;
+```
+
+Add stable fallback functions near the Lynx runtime helpers:
+
+```ts
+const requestAnimationFrameBasedSTO = (callback: FrameRequestCallback): number => rafBasedSto.call(callback);
+const cancelAnimationFrameBasedSTO = (handle: number): void => rafBasedSto.clear(handle);
+```
+
+Cache them on `LynxEnvContribution`:
+
+```ts
+private requestAnimationFrame = requestAnimationFrameBasedSTO;
+private cancelAnimationFrame = cancelAnimationFrameBasedSTO;
+```
+
+After resolving `this.lynxRuntime` in `configure()`, atomically select the pair:
+
+```ts
+if (
+  typeof this.lynxRuntime?.requestAnimationFrame === 'function' &&
+  typeof this.lynxRuntime?.cancelAnimationFrame === 'function'
+) {
+  this.requestAnimationFrame = this.lynxRuntime.requestAnimationFrame.bind(this.lynxRuntime);
+  this.cancelAnimationFrame = this.lynxRuntime.cancelAnimationFrame.bind(this.lynxRuntime);
+} else {
+  this.requestAnimationFrame = requestAnimationFrameBasedSTO;
+  this.cancelAnimationFrame = cancelAnimationFrameBasedSTO;
+}
+```
+
+Replace the legacy copied miniapp implementation:
+
+```ts
+getRequestAnimationFrame(): (callback: FrameRequestCallback) => number {
+  return this.requestAnimationFrame;
+}
+
+getCancelAnimationFrame(): (handle: number) => void {
+  return this.cancelAnimationFrame;
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+cd packages/vrender-kits
+rushx test -- --runInBand __tests__/unit/lynx-window-event.test.ts
+```
+
+Expected: all tests in `lynx-window-event.test.ts` pass with no warnings or open handles.
+
+- [ ] **Step 5: Run impacted-package and entry validation**
+
+Run:
+
+```bash
+cd packages/vrender-kits
+rushx test -- --runInBand
+rushx compile
+./node_modules/.bin/eslint src/env/contributions/lynx-contribution.ts __tests__/unit/lynx-window-event.test.ts
+cd ../vrender
+rushx test -- --runInBand __tests__/unit/entries.test.ts __tests__/unit/shared-app.test.ts
+```
+
+Expected: every command exits with status 0.
+
+- [ ] **Step 6: Review and commit the implementation**
+
+Run:
+
+```bash
+git diff --check
+git diff -- packages/vrender-kits/src/env/contributions/lynx-contribution.ts packages/vrender-kits/__tests__/unit/lynx-window-event.test.ts
+git status --short
+git add packages/vrender-kits/src/env/contributions/lynx-contribution.ts packages/vrender-kits/__tests__/unit/lynx-window-event.test.ts
+git diff --cached --check
+git commit -m "fix(lynx): prefer native animation frames"
+```
+
+Expected: the commit contains only the Lynx scheduler implementation and its tests.

--- a/docs/superpowers/specs/2026-07-24-lynx-native-raf-design.md
+++ b/docs/superpowers/specs/2026-07-24-lynx-native-raf-design.md
@@ -1,0 +1,75 @@
+# Lynx Native RAF Design
+
+## Context
+
+`LynxEnvContribution` currently implements VRender's animation-frame API with
+`rafBasedSto`, which is backed by `setTimeout`. Modern Lynx runtimes expose
+`requestAnimationFrame` and `cancelAnimationFrame`, so the current default does
+not align animation ticks with the host's VSYNC.
+
+## Goal
+
+Use the Lynx runtime's native animation-frame scheduler by default while
+preserving compatibility with hosts that do not expose the complete native
+scheduler pair.
+
+## Non-goals
+
+- Change ticker or timeline semantics in `@visactor/vrender-animate`.
+- Change animation scheduling for browser, Node, Harmony, Feishu, TT, WX, or
+  Taro environments.
+- Add a new public scheduler option to Lynx environment parameters.
+
+## Design
+
+Extend the internal `LynxRuntime` type with `requestAnimationFrame` and
+`cancelAnimationFrame`.
+
+`LynxEnvContribution.configure()` selects the scheduler once:
+
+- If both native methods are functions, bind both methods to the selected Lynx
+  runtime and cache them.
+- If either method is unavailable, cache the existing `rafBasedSto` request and
+  cancel functions as a pair.
+
+`getRequestAnimationFrame()` and `getCancelAnimationFrame()` return the cached
+functions without repeated capability checks or wrapper allocation in the
+animation scheduling path.
+
+Treating request and cancel as an atomic pair prevents a native RAF handle from
+being passed to `clearTimeout`, or a timeout handle from being passed to the
+native Lynx cancellation API.
+
+## Compatibility and lifecycle
+
+The existing `rafBasedSto` behavior remains the fallback, so older or restricted
+Lynx hosts retain their current animation behavior. Scheduler selection follows
+the existing environment lifecycle: a later `configure()` call re-evaluates the
+runtime and replaces the cached pair.
+
+Native methods are bound to the runtime object because a host implementation may
+depend on its receiver.
+
+## Tests
+
+Add focused unit coverage in the existing Lynx environment test file:
+
+- A complete native scheduler pair is preferred, returns the host handle, calls
+  both host methods with the Lynx runtime as `this`, and forwards the callback.
+- A runtime with an incomplete native scheduler pair uses `rafBasedSto` for both
+  request and cancellation.
+
+The new native-scheduler test must fail before the implementation is added.
+
+## Validation
+
+Run:
+
+- The focused Lynx environment unit test.
+- The full `@visactor/vrender-kits` unit test suite.
+- `rushx compile` in `packages/vrender-kits`.
+- ESLint for the changed source and test files without automatic fixes.
+
+No benchmark is required because the change removes timer adaptation from the
+default Lynx path and performs capability selection only during environment
+configuration, not per animation frame.

--- a/packages/vrender-kits/__tests__/unit/lynx-window-event.test.ts
+++ b/packages/vrender-kits/__tests__/unit/lynx-window-event.test.ts
@@ -90,6 +90,84 @@ describe('lynx window event contribution', () => {
     });
   });
 
+  test('uses the complete native lynx animation frame scheduler pair', () => {
+    const env = new LynxEnvContribution();
+    const service = {
+      env: 'lynx',
+      setActiveEnvContribution: (): void => undefined
+    };
+    let requestReceiver: unknown;
+    let cancelReceiver: unknown;
+    let scheduledCallback: FrameRequestCallback;
+    let cancelledHandle: number;
+    const runtime = {
+      requestAnimationFrame(this: unknown, callback: FrameRequestCallback) {
+        requestReceiver = this;
+        scheduledCallback = callback;
+        return 17;
+      },
+      cancelAnimationFrame(this: unknown, handle: number) {
+        cancelReceiver = this;
+        cancelledHandle = handle;
+      }
+    };
+    const callback = (): void => undefined;
+
+    env.configure(service as any, { lynx: runtime as any });
+
+    expect(env.getRequestAnimationFrame()(callback)).toBe(17);
+    env.getCancelAnimationFrame()(17);
+
+    expect(requestReceiver).toBe(runtime);
+    expect(cancelReceiver).toBe(runtime);
+    expect(scheduledCallback).toBe(callback);
+    expect(cancelledHandle).toBe(17);
+  });
+
+  test('falls back as a pair when the native lynx scheduler is incomplete', () => {
+    jest.useFakeTimers();
+    try {
+      const env = new LynxEnvContribution();
+      const service = {
+        env: 'lynx',
+        setActiveEnvContribution: (): void => undefined
+      };
+      let completeNativeRequestCallCount = 0;
+      let nativeRequestCallCount = 0;
+      let callbackCalled = false;
+
+      env.configure(service as any, {
+        lynx: {
+          requestAnimationFrame: () => {
+            completeNativeRequestCallCount++;
+            return 23;
+          },
+          cancelAnimationFrame: (): void => undefined
+        } as any
+      });
+      env.configure(service as any, {
+        lynx: {
+          requestAnimationFrame: () => {
+            nativeRequestCallCount++;
+            return 17;
+          }
+        } as any
+      });
+
+      const handle = env.getRequestAnimationFrame()(() => {
+        callbackCalled = true;
+      });
+      env.getCancelAnimationFrame()(handle);
+      jest.runOnlyPendingTimers();
+
+      expect(completeNativeRequestCallCount).toBe(0);
+      expect(nativeRequestCallCount).toBe(0);
+      expect(callbackCalled).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('reports missing lynx canvas bridge with a clear error', () => {
     const env = new LynxEnvContribution();
     const service = {

--- a/packages/vrender-kits/src/env/contributions/lynx-contribution.ts
+++ b/packages/vrender-kits/src/env/contributions/lynx-contribution.ts
@@ -39,6 +39,8 @@ type LynxRuntime = Partial<{
   createCanvasNG: (id?: string) => any;
   createImage: (id: string) => any;
   createOffscreenCanvas: () => any;
+  requestAnimationFrame: (callback: FrameRequestCallback) => number;
+  cancelAnimationFrame: (handle: number) => void;
   krypton: LynxKryptonRuntime;
 }>;
 
@@ -127,6 +129,9 @@ function getGlobalSystemPixelRatio(): number | undefined {
 function getLynxRuntime(params?: LynxEnvParams): LynxRuntime | undefined {
   return params?.lynx ?? params?.runtime ?? getGlobalLynxRuntime();
 }
+
+const requestAnimationFrameBasedSTO = (callback: FrameRequestCallback): number => rafBasedSto.call(callback);
+const cancelAnimationFrameBasedSTO = (handle: number): void => rafBasedSto.clear(handle);
 
 function getLynxPixelRatio(params?: LynxEnvParams, runtime?: LynxRuntime): number {
   return params?.pixelRatio ?? runtime?.getSystemInfoSync?.()?.pixelRatio ?? getGlobalSystemPixelRatio() ?? 1;
@@ -257,6 +262,8 @@ export class LynxEnvContribution extends BaseEnvContribution implements IEnvCont
   canvasIdx: number = 0;
   private lynxRuntime?: LynxRuntime;
   private lynxEnvParams?: LynxEnvParams;
+  private requestAnimationFrame = requestAnimationFrameBasedSTO;
+  private cancelAnimationFrame = cancelAnimationFrameBasedSTO;
 
   constructor() {
     super();
@@ -278,6 +285,17 @@ export class LynxEnvContribution extends BaseEnvContribution implements IEnvCont
       service.setActiveEnvContribution(this);
       this.lynxEnvParams = params;
       this.lynxRuntime = getLynxRuntime(params);
+
+      if (
+        typeof this.lynxRuntime?.requestAnimationFrame === 'function' &&
+        typeof this.lynxRuntime?.cancelAnimationFrame === 'function'
+      ) {
+        this.requestAnimationFrame = this.lynxRuntime.requestAnimationFrame.bind(this.lynxRuntime);
+        this.cancelAnimationFrame = this.lynxRuntime.cancelAnimationFrame.bind(this.lynxRuntime);
+      } else {
+        this.requestAnimationFrame = requestAnimationFrameBasedSTO;
+        this.cancelAnimationFrame = cancelAnimationFrameBasedSTO;
+      }
 
       // loadFeishuContributions();
     }
@@ -375,23 +393,11 @@ export class LynxEnvContribution extends BaseEnvContribution implements IEnvCont
   }
 
   getRequestAnimationFrame(): (callback: FrameRequestCallback) => number {
-    // return requestAnimationFrame;
-
-    // 飞书小组件，在云文档浏览器环境中，没有requestAnimationFrame
-    // 但是在小组件工作台环境和模拟器中正常
-    // 反馈飞书修改，目前先使用setTimeout模拟，进行测试，飞书修复后替换回requestAnimationFrame
-    // return function (callback: FrameRequestCallback) {
-    //   return setTimeout(callback, 1000 / 60, true);
-    // } as any;
-    return function (callback: FrameRequestCallback) {
-      return rafBasedSto.call(callback);
-    } as any;
+    return this.requestAnimationFrame;
   }
 
-  getCancelAnimationFrame(): (h: number) => void {
-    return (h: number) => {
-      rafBasedSto.clear(h);
-    };
+  getCancelAnimationFrame(): (handle: number) => void {
+    return this.cancelAnimationFrame;
   }
 
   mapToCanvasPoint(event: any) {


### PR DESCRIPTION
### 🤔 这个分支是...

- [ ] 新功能
- [x] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [x] 测试 case 更新
- [ ] 分支合并
- [x] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 连接

N/A

### 🐞 Bugserver 用例 id

N/A

### 💡 问题的背景&解决方案

Lynx 环境此前直接复用了基于 `setTimeout` 的 `rafBasedSto`。这段逻辑来自通用小程序环境的历史兼容实现，没有使用 Lynx runtime 已提供的原生 `requestAnimationFrame` / `cancelAnimationFrame`，导致动画调度无法跟随宿主帧节奏。

本 PR 在 `LynxEnvContribution.configure()` 的低频配置阶段选择并缓存调度器：

- 仅当 native request/cancel 两个 API 都存在时成对启用，并绑定 Lynx runtime 作为 `this`；
- 任一 API 缺失时，request/cancel 成对回退到现有 `rafBasedSto`，保持兼容；
- 重复 configure 会重新评估能力，避免残留上一轮 scheduler；
- 动画热路径只调用已缓存函数，不增加逐帧 capability 判断或对象分配。

新增单测覆盖原生 scheduler、runtime receiver、handle 透传、原子 fallback 与 native → fallback 的重复配置场景。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prefer the native Lynx animation-frame scheduler when both request and cancel APIs are available, with an atomic timeout-backed fallback. |
| 🇨🇳 Chinese | Lynx 环境在 request/cancel API 完整时默认使用原生动画帧调度，并在能力不完整时成对回退到 timeout 模拟实现。 |

### ☑️ 自测

- [x] 文档提供了，或者更新，或者不需要
- [x] Demo 提供了，或者更新，或者不需要
- [x] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

验证：

- `rush build -t @visactor/vrender`
- `packages/vrender-kits`: 30 suites / 98 tests passed
- `packages/vrender-kits`: `rushx compile`
- changed-file ESLint passed
- `packages/vrender`: entry/shared-app 2 suites / 15 tests passed
- `packages/vrender`: `rushx compile`
- pre-push `rush test --only tag:package` passed for all 7 published packages
- 独立代码评审：无 Critical / Important 问题

未执行：Lynx 真机/宿主 smoke（当前环境没有 Lynx 宿主）。

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
