### PR TITLE
fix(core): clear globalZIndex synchronously on state exit

### DIFF
--- a/packages/vrender-core/__tests__/unit/graphic/state-animation.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/state-animation.test.ts
@@ -322,14 +322,19 @@ describe('Graphic state animation integration', () => {
     );
   });
 
-  test('should animate a removed rect alias back to its derived static value when changing states', () => {
+  test('should derive a removed rect alias from the target static state when changing states', () => {
     const graphic = createGraphic();
+    delete (graphic as any).baseAttributes.width;
+    delete (graphic.attribute as any).width;
+    (graphic as any).baseAttributes.x1 = 10;
+    (graphic.attribute as any).x1 = 10;
     graphic.states = {
       hover: {
-        x1: 40
+        width: 40
       },
       selected: {
-        fill: 'green'
+        x: 5,
+        x1: 30
       }
     } as any;
     const applyAnimationState = jest.fn();
@@ -344,7 +349,7 @@ describe('Graphic state animation integration', () => {
         {
           name: 'state',
           animation: expect.objectContaining({
-            to: expect.objectContaining({ x1: 10 })
+            to: expect.objectContaining({ width: 25 })
           })
         }
       ]

--- a/packages/vrender-core/__tests__/unit/graphic/state-animation.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/state-animation.test.ts
@@ -296,6 +296,61 @@ describe('Graphic state animation integration', () => {
     expect(graphic.attribute.globalZIndex).toBeUndefined();
   });
 
+  test('should animate a removed rect alias back to its derived static value when clearing states', () => {
+    const graphic = createGraphic();
+    graphic.states = {
+      hover: {
+        x1: 40
+      }
+    } as any;
+    const applyAnimationState = jest.fn();
+    (graphic as any).applyAnimationState = applyAnimationState;
+
+    graphic.useStates(['hover'], true);
+    graphic.clearStates(true);
+
+    expect(applyAnimationState).toHaveBeenLastCalledWith(
+      ['state'],
+      [
+        {
+          name: 'state',
+          animation: expect.objectContaining({
+            to: expect.objectContaining({ x1: 10 })
+          })
+        }
+      ]
+    );
+  });
+
+  test('should animate a removed rect alias back to its derived static value when changing states', () => {
+    const graphic = createGraphic();
+    graphic.states = {
+      hover: {
+        x1: 40
+      },
+      selected: {
+        fill: 'green'
+      }
+    } as any;
+    const applyAnimationState = jest.fn();
+    (graphic as any).applyAnimationState = applyAnimationState;
+
+    graphic.useStates(['hover'], true);
+    graphic.useStates(['selected'], true);
+
+    expect(applyAnimationState).toHaveBeenLastCalledWith(
+      ['state'],
+      [
+        {
+          name: 'state',
+          animation: expect.objectContaining({
+            to: expect.objectContaining({ x1: 10 })
+          })
+        }
+      ]
+    );
+  });
+
   test('should allow explicit animateConfig to override graphic and context defaults in applyStateAttrs', () => {
     const graphic = createGraphic();
     graphic.stateAnimateConfig = {

--- a/packages/vrender-core/__tests__/unit/graphic/state-animation.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/state-animation.test.ts
@@ -279,6 +279,23 @@ describe('Graphic state animation integration', () => {
     );
   });
 
+  test('should synchronously remove a no-work state attribute when clearing states', () => {
+    const graphic = createGraphic();
+    graphic.states = {
+      hover: {
+        globalZIndex: 400
+      }
+    } as any;
+
+    graphic.useStates(['hover'], true);
+
+    expect(graphic.attribute.globalZIndex).toBe(400);
+
+    graphic.clearStates(true);
+
+    expect(graphic.attribute.globalZIndex).toBeUndefined();
+  });
+
   test('should allow explicit animateConfig to override graphic and context defaults in applyStateAttrs', () => {
     const graphic = createGraphic();
     graphic.stateAnimateConfig = {

--- a/packages/vrender-core/__tests__/unit/graphic/state-transition-orchestrator.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/state-transition-orchestrator.test.ts
@@ -426,6 +426,20 @@ describe('StateTransitionOrchestrator', () => {
     expect(plan.targetAttrs).not.toHaveProperty('fillOpacity');
   });
 
+  test('should retain an undefined removed attribute when no default resolver is provided', () => {
+    const orchestrator = new StateTransitionOrchestrator<any>();
+
+    const plan = orchestrator.analyzeTransition({}, true, {
+      extraAnimateAttrs: {
+        fillOpacity: undefined
+      }
+    });
+
+    expect(plan.animateAttrs).toEqual({
+      fillOpacity: undefined
+    });
+  });
+
   test('should allow extra animation attrs to replace an undefined clear target transiently', () => {
     const orchestrator = new StateTransitionOrchestrator<any>();
 

--- a/packages/vrender-core/src/graphic/graphic.ts
+++ b/packages/vrender-core/src/graphic/graphic.ts
@@ -755,19 +755,16 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       };
 
       if (hasTargetAttr) {
-        assignFallbackAttr(this.getStateTransitionDefaultAttribute(key, staticTargetAttrs));
+        assignFallbackAttr((targetStateAttrs as Record<string, any>)[key]);
         return;
       }
 
       if (Object.prototype.hasOwnProperty.call(snapshot, key)) {
-        const snapshotValue = snapshot[key];
-        assignFallbackAttr(
-          snapshotValue === undefined ? this.getStateTransitionDefaultAttribute(key, staticTargetAttrs) : snapshotValue
-        );
+        assignFallbackAttr(snapshot[key]);
         return;
       }
 
-      assignFallbackAttr(this.getStateTransitionDefaultAttribute(key, staticTargetAttrs));
+      assignFallbackAttr(undefined);
     });
 
     return extraAttrs as Partial<T>;

--- a/packages/vrender-core/src/graphic/graphic.ts
+++ b/packages/vrender-core/src/graphic/graphic.ts
@@ -732,14 +732,13 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
   protected buildRemovedStateAnimationAttrs(
     targetStateAttrs: Partial<T>,
     previousResolvedStatePatch?: Partial<T>
-  ): Partial<T> {
-    const extraAttrs: Record<string, any> = {};
-
+  ): { extraAttrs: Partial<T>; stateTransitionTargetAttrs: Partial<T> } | undefined {
     if (!previousResolvedStatePatch) {
-      return extraAttrs as Partial<T>;
+      return;
     }
 
     const snapshot = this.buildStaticAttributeSnapshot() as Record<string, any>;
+    const extraAttrs: Record<string, any> = {};
     Object.keys(previousResolvedStatePatch).forEach(key => {
       const hasTargetAttr = Object.prototype.hasOwnProperty.call(targetStateAttrs, key);
       if (hasTargetAttr && (targetStateAttrs as Record<string, any>)[key] !== undefined) {
@@ -763,7 +762,10 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       assignFallbackAttr(undefined);
     });
 
-    return extraAttrs as Partial<T>;
+    return {
+      extraAttrs: extraAttrs as Partial<T>,
+      stateTransitionTargetAttrs: snapshot as Partial<T>
+    };
   }
 
   protected syncObjectToSnapshot(
@@ -2272,13 +2274,18 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
 
     if (hasAnimation && animateSameStatePatchChange) {
       this._syncFinalAttributeFromStaticTruth();
+      const removedStateAnimationAttrs = this.buildRemovedStateAnimationAttrs(
+        resolvedStateAttrs,
+        previousResolvedStatePatch
+      );
       this.applyStateAttrs(
         resolvedStateAttrs,
         transition.states,
         hasAnimation,
         false,
         undefined,
-        this.buildRemovedStateAnimationAttrs(resolvedStateAttrs, previousResolvedStatePatch)
+        removedStateAnimationAttrs?.extraAttrs,
+        removedStateAnimationAttrs?.stateTransitionTargetAttrs
       );
     } else {
       this.stopStateAnimates();
@@ -2303,18 +2310,23 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     hasAnimation?: boolean,
     isClear?: boolean,
     animateConfig?: IAnimateConfig,
-    extraAnimateAttrs?: Partial<T>
+    extraAnimateAttrs?: Partial<T>,
+    stateTransitionTargetAttrs?: Partial<T>
   ) {
     const resolvedAnimateConfig = hasAnimation ? this.resolveStateAnimateConfig(animateConfig) : undefined;
     const transitionOptions = resolvedAnimateConfig
       ? {
           animateConfig: resolvedAnimateConfig,
           extraAnimateAttrs: extraAnimateAttrs as Record<string, unknown>,
-          getStateTransitionDefaultAttribute: this.getStateTransitionDefaultAttribute.bind(this),
+          getStateTransitionDefaultAttribute: this.getStateTransitionDefaultAttribute.bind(this) as (
+            key: string,
+            targetAttrs?: Record<string, unknown>
+          ) => unknown,
           shouldSkipDefaultAttribute: this.shouldSkipStateTransitionDefaultAttribute.bind(this) as (
             key: string,
             targetAttrs: Record<string, unknown>
-          ) => boolean
+          ) => boolean,
+          stateTransitionTargetAttrs: stateTransitionTargetAttrs as Record<string, unknown>
         }
       : undefined;
 
@@ -2327,11 +2339,15 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       noWorkAnimateAttr: this.getNoWorkAnimateAttr(),
       animateConfig: resolvedAnimateConfig,
       extraAnimateAttrs: extraAnimateAttrs as Record<string, unknown>,
-      getStateTransitionDefaultAttribute: this.getStateTransitionDefaultAttribute.bind(this),
+      getStateTransitionDefaultAttribute: this.getStateTransitionDefaultAttribute.bind(this) as (
+        key: string,
+        targetAttrs?: Record<string, unknown>
+      ) => unknown,
       shouldSkipDefaultAttribute: this.shouldSkipStateTransitionDefaultAttribute.bind(this) as (
         key: string,
         targetAttrs: Record<string, unknown>
-      ) => boolean
+      ) => boolean,
+      stateTransitionTargetAttrs: stateTransitionTargetAttrs as Record<string, unknown>
     });
 
     this.getStateTransitionOrchestrator().applyTransition(this as any, plan, hasAnimation, transitionOptions);
@@ -2399,13 +2415,18 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     this.clearSharedStateActiveRegistrations();
     if (hasAnimation) {
       this._syncFinalAttributeFromStaticTruth();
+      const removedStateAnimationAttrs = this.buildRemovedStateAnimationAttrs(
+        resolvedStateAttrs,
+        previousResolvedStatePatch
+      );
       this.applyStateAttrs(
         resolvedStateAttrs,
         transition.states,
         hasAnimation,
         true,
         undefined,
-        this.buildRemovedStateAnimationAttrs(resolvedStateAttrs, previousResolvedStatePatch)
+        removedStateAnimationAttrs?.extraAttrs,
+        removedStateAnimationAttrs?.stateTransitionTargetAttrs
       );
     } else {
       this.stopStateAnimates();
@@ -2500,13 +2521,18 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     this.syncSharedStateActiveRegistrations();
     if (hasAnimation) {
       this._syncFinalAttributeFromStaticTruth();
+      const removedStateAnimationAttrs = this.buildRemovedStateAnimationAttrs(
+        resolvedStateAttrs,
+        previousResolvedStatePatch
+      );
       this.applyStateAttrs(
         resolvedStateAttrs,
         transition.states,
         hasAnimation,
         false,
         undefined,
-        this.buildRemovedStateAnimationAttrs(resolvedStateAttrs, previousResolvedStatePatch)
+        removedStateAnimationAttrs?.extraAttrs,
+        removedStateAnimationAttrs?.stateTransitionTargetAttrs
       );
     } else {
       this.stopStateAnimates();

--- a/packages/vrender-core/src/graphic/graphic.ts
+++ b/packages/vrender-core/src/graphic/graphic.ts
@@ -740,7 +740,6 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     }
 
     const snapshot = this.buildStaticAttributeSnapshot() as Record<string, any>;
-    const staticTargetAttrs = snapshot as Partial<T>;
     Object.keys(previousResolvedStatePatch).forEach(key => {
       const hasTargetAttr = Object.prototype.hasOwnProperty.call(targetStateAttrs, key);
       if (hasTargetAttr && (targetStateAttrs as Record<string, any>)[key] !== undefined) {
@@ -748,9 +747,6 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       }
 
       const assignFallbackAttr = (value: any): void => {
-        if (value === undefined && this.shouldSkipStateTransitionDefaultAttribute(key, staticTargetAttrs)) {
-          return;
-        }
         extraAttrs[key] = value === undefined ? value : cloneAttributeValue(value);
       };
 
@@ -2314,6 +2310,7 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       ? {
           animateConfig: resolvedAnimateConfig,
           extraAnimateAttrs: extraAnimateAttrs as Record<string, unknown>,
+          getStateTransitionDefaultAttribute: this.getStateTransitionDefaultAttribute.bind(this),
           shouldSkipDefaultAttribute: this.shouldSkipStateTransitionDefaultAttribute.bind(this) as (
             key: string,
             targetAttrs: Record<string, unknown>
@@ -2330,6 +2327,7 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
       noWorkAnimateAttr: this.getNoWorkAnimateAttr(),
       animateConfig: resolvedAnimateConfig,
       extraAnimateAttrs: extraAnimateAttrs as Record<string, unknown>,
+      getStateTransitionDefaultAttribute: this.getStateTransitionDefaultAttribute.bind(this),
       shouldSkipDefaultAttribute: this.shouldSkipStateTransitionDefaultAttribute.bind(this) as (
         key: string,
         targetAttrs: Record<string, unknown>

--- a/packages/vrender-core/src/graphic/state/state-transition-orchestrator.ts
+++ b/packages/vrender-core/src/graphic/state/state-transition-orchestrator.ts
@@ -12,17 +12,19 @@ export interface IStateTransitionAnalysisOptions {
   noWorkAnimateAttr?: Record<string, number>;
   isClear?: boolean;
   getDefaultAttribute?: (key: string) => unknown;
-  getStateTransitionDefaultAttribute?: (key: string) => unknown;
+  getStateTransitionDefaultAttribute?: (key: string, targetAttrs?: Record<string, unknown>) => unknown;
   shouldSkipDefaultAttribute?: (key: string, targetAttrs: Record<string, unknown>) => boolean;
   animateConfig?: IAnimateConfig;
   extraAnimateAttrs?: Record<string, unknown>;
+  stateTransitionTargetAttrs?: Record<string, unknown>;
 }
 
 export interface IStateTransitionApplyOptions {
   animateConfig?: IAnimateConfig;
   extraAnimateAttrs?: Record<string, unknown>;
-  getStateTransitionDefaultAttribute?: (key: string) => unknown;
+  getStateTransitionDefaultAttribute?: (key: string, targetAttrs?: Record<string, unknown>) => unknown;
   shouldSkipDefaultAttribute?: (key: string, targetAttrs: Record<string, unknown>) => boolean;
+  stateTransitionTargetAttrs?: Record<string, unknown>;
 }
 
 export interface IStateTransitionGraphic<T> {
@@ -110,9 +112,10 @@ export class StateTransitionOrchestrator<T extends Record<string, any> = Record<
     const getDefaultAttribute = options.getDefaultAttribute;
     const readDefaultAttribute = getDefaultAttribute as (key: string) => unknown;
     const readStateTransitionDefaultAttribute = (options.getStateTransitionDefaultAttribute ?? getDefaultAttribute) as
-      | ((key: string) => unknown)
+      | ((key: string, targetAttrs?: Record<string, unknown>) => unknown)
       | undefined;
     const shouldSkipDefaultAttribute = options.shouldSkipDefaultAttribute;
+    const stateTransitionTargetAttrs = options.stateTransitionTargetAttrs ?? (targetAttrs as Record<string, unknown>);
 
     const assignTransitionAttr = (key: string, value: any, isRemovedStateAttr: boolean = false): void => {
       if (noWorkAnimateAttr[key]) {
@@ -121,8 +124,8 @@ export class StateTransitionOrchestrator<T extends Record<string, any> = Record<
       }
 
       if (isRemovedStateAttr && value === undefined) {
-        const defaultValue = readStateTransitionDefaultAttribute?.(key);
-        if (defaultValue === undefined && shouldSkipDefaultAttribute?.(key, targetAttrs as Record<string, unknown>)) {
+        const defaultValue = readStateTransitionDefaultAttribute?.(key, stateTransitionTargetAttrs);
+        if (defaultValue === undefined && shouldSkipDefaultAttribute?.(key, stateTransitionTargetAttrs)) {
           return;
         }
         (plan.animateAttrs as Record<string, any>)[key] = defaultValue;
@@ -220,7 +223,8 @@ export class StateTransitionOrchestrator<T extends Record<string, any> = Record<
       shouldSkipDefaultAttribute:
         options.shouldSkipDefaultAttribute ?? graphic.shouldSkipStateTransitionDefaultAttribute.bind(graphic),
       animateConfig: options.animateConfig,
-      extraAnimateAttrs: options.extraAnimateAttrs
+      extraAnimateAttrs: options.extraAnimateAttrs,
+      stateTransitionTargetAttrs: options.stateTransitionTargetAttrs
     });
 
     return this.applyTransition(graphic, plan, hasAnimation, options);

--- a/packages/vrender-core/src/graphic/state/state-transition-orchestrator.ts
+++ b/packages/vrender-core/src/graphic/state/state-transition-orchestrator.ts
@@ -12,6 +12,7 @@ export interface IStateTransitionAnalysisOptions {
   noWorkAnimateAttr?: Record<string, number>;
   isClear?: boolean;
   getDefaultAttribute?: (key: string) => unknown;
+  getStateTransitionDefaultAttribute?: (key: string) => unknown;
   shouldSkipDefaultAttribute?: (key: string, targetAttrs: Record<string, unknown>) => boolean;
   animateConfig?: IAnimateConfig;
   extraAnimateAttrs?: Record<string, unknown>;
@@ -20,6 +21,7 @@ export interface IStateTransitionAnalysisOptions {
 export interface IStateTransitionApplyOptions {
   animateConfig?: IAnimateConfig;
   extraAnimateAttrs?: Record<string, unknown>;
+  getStateTransitionDefaultAttribute?: (key: string) => unknown;
   shouldSkipDefaultAttribute?: (key: string, targetAttrs: Record<string, unknown>) => boolean;
 }
 
@@ -107,11 +109,23 @@ export class StateTransitionOrchestrator<T extends Record<string, any> = Record<
     const isClear = options.isClear === true;
     const getDefaultAttribute = options.getDefaultAttribute;
     const readDefaultAttribute = getDefaultAttribute as (key: string) => unknown;
+    const readStateTransitionDefaultAttribute = (options.getStateTransitionDefaultAttribute ?? getDefaultAttribute) as
+      | ((key: string) => unknown)
+      | undefined;
     const shouldSkipDefaultAttribute = options.shouldSkipDefaultAttribute;
 
-    const assignTransitionAttr = (key: string, value: any): void => {
+    const assignTransitionAttr = (key: string, value: any, isRemovedStateAttr: boolean = false): void => {
       if (noWorkAnimateAttr[key]) {
         (plan.noAnimateAttrs as Record<string, any>)[key] = value;
+        return;
+      }
+
+      if (isRemovedStateAttr && value === undefined) {
+        const defaultValue = readStateTransitionDefaultAttribute?.(key);
+        if (defaultValue === undefined && shouldSkipDefaultAttribute?.(key, targetAttrs as Record<string, unknown>)) {
+          return;
+        }
+        (plan.animateAttrs as Record<string, any>)[key] = defaultValue;
         return;
       }
 
@@ -145,7 +159,7 @@ export class StateTransitionOrchestrator<T extends Record<string, any> = Record<
         ) {
           continue;
         }
-        assignTransitionAttr(key, (extraAnimateAttrs as Record<string, any>)[key]);
+        assignTransitionAttr(key, (extraAnimateAttrs as Record<string, any>)[key], true);
       }
     }
 
@@ -202,6 +216,7 @@ export class StateTransitionOrchestrator<T extends Record<string, any> = Record<
       noWorkAnimateAttr: graphic.getNoWorkAnimateAttr(),
       isClear: true,
       getDefaultAttribute: graphic.getDefaultAttribute.bind(graphic),
+      getStateTransitionDefaultAttribute: options.getStateTransitionDefaultAttribute,
       shouldSkipDefaultAttribute:
         options.shouldSkipDefaultAttribute ?? graphic.shouldSkipStateTransitionDefaultAttribute.bind(graphic),
       animateConfig: options.animateConfig,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

Fixes VisActor/VChart#4632

### 🐞 Bugserver case id

Not applicable — this core state-transition regression is covered by a unit test.

### 💡 Background and solution

When a state animation exits, `buildRemovedStateAnimationAttrs()` previously replaced a missing static `globalZIndex` with the theme default `1`. Since this property is non-interpolable, `1` was committed immediately and kept the interactive-layer clone alive until the animation finished, causing synchronized funnel labels to flicker.

The state-exit builder now preserves missing or explicit `undefined` static targets and leaves recovery to the existing transition orchestrator. Non-animatable attributes therefore clear synchronously, while animatable attributes continue to resolve their theme defaults during animation planning. The regression test asserts that `clearStates(true)` returns with `globalZIndex` unset and retains the existing `fillOpacity` and `lineWidth` default-restoration coverage.

### 📝 Changelog

| Language | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix delayed removal of interactive-layer graphics after clearing a `globalZIndex` state. |
| 🇨🇳 Chinese | 修复清除 `globalZIndex` 状态后交互层图元延迟移除导致的标签闪动。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

Validation:

- `cd packages/vrender-core && rushx test --runInBand` (105 suites passed, 606 tests passed)
- `rush compile -t @visactor/vrender-core`
- `cd packages/vrender-core && rushx build`

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough