### PR TITLE
fix(core): keep the globalZIndex clone aligned with its source graphic

### DIFF
--- a/packages/vrender-core/__tests__/unit/render/interactive-graphic-bounds.test.ts
+++ b/packages/vrender-core/__tests__/unit/render/interactive-graphic-bounds.test.ts
@@ -1,3 +1,4 @@
+import { Matrix } from '@visactor/vutils';
 import { InteractiveDrawItemInterceptorContribution } from '../../../src/render/contributions/render/draw-interceptor';
 import { createCircle } from '../../../src/graphic/circle';
 import { createGroup } from '../../../src/graphic/group';
@@ -46,6 +47,17 @@ function expectSamePlacement(actual: any, expected: any) {
   expect(actual.f).toBeCloseTo(expected.f);
 }
 
+function hoist(graphic: any) {
+  const { hoisted, drawContext } = createDrawContextStub();
+  const handled = new InteractiveDrawItemInterceptorContribution().beforeSetInteractive(
+    graphic,
+    {} as any,
+    drawContext as any,
+    {} as any
+  );
+  return { handled, hoisted };
+}
+
 describe('interactive graphic bounds', () => {
   test('keeps the hoisted clone aligned with the source graphic under a transformed parent', () => {
     const parent = createGroup({ x: 100, y: 80 });
@@ -79,6 +91,64 @@ describe('interactive graphic bounds', () => {
     );
 
     expect(circle.interactiveGraphic.attribute.postMatrix).toBeUndefined();
+    expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
+  });
+
+  test('keeps the source postMatrix while adding the ancestor transform', () => {
+    const parent = createGroup({ x: 100, y: 80 });
+    const circle = createCircle({
+      x: 150,
+      y: 100,
+      radius: 12,
+      globalZIndex: 100,
+      postMatrix: new Matrix(1, 0, 0, 1, 30, 20)
+    });
+    parent.add(circle);
+
+    hoist(circle);
+
+    expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
+  });
+
+  test('accounts for the parent scroll that doUpdateGlobalMatrix applies after the local matrix', () => {
+    const parent = createGroup({ x: 100, y: 80, scrollX: 30, scrollY: 20 });
+    const circle = createCircle({ x: 150, y: 100, radius: 12, globalZIndex: 100 });
+    parent.add(circle);
+
+    hoist(circle);
+
+    expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
+  });
+
+  test('handles a scaled ancestor, a source postMatrix and a parent scroll together', () => {
+    const parent = createGroup({ x: 100, y: 80, scaleX: 2, scaleY: 3, scrollX: 30, scrollY: 20 });
+    const circle = createCircle({
+      x: 150,
+      y: 100,
+      radius: 12,
+      scaleX: 1.5,
+      angle: Math.PI / 6,
+      globalZIndex: 100,
+      postMatrix: new Matrix(1, 0, 0, 1, 30, 20)
+    });
+    parent.add(circle);
+
+    hoist(circle);
+
+    expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
+  });
+
+  test('reuses the cached matrix instead of allocating one per pass', () => {
+    const parent = createGroup({ x: 100, y: 80 });
+    const circle = createCircle({ x: 150, y: 100, radius: 12, globalZIndex: 100 });
+    parent.add(circle);
+
+    hoist(circle);
+    const first = circle.interactiveGraphic.attribute.postMatrix;
+
+    hoist(circle);
+
+    expect(circle.interactiveGraphic.attribute.postMatrix).toBe(first);
     expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
   });
 });

--- a/packages/vrender-core/__tests__/unit/render/interactive-graphic-bounds.test.ts
+++ b/packages/vrender-core/__tests__/unit/render/interactive-graphic-bounds.test.ts
@@ -1,0 +1,84 @@
+import { InteractiveDrawItemInterceptorContribution } from '../../../src/render/contributions/render/draw-interceptor';
+import { createCircle } from '../../../src/graphic/circle';
+import { createGroup } from '../../../src/graphic/group';
+
+/**
+ * 交互层只需要一个能收下克隆的 shadowRoot，这里直接给现成的，
+ * 免得为了走通 attachShadow 再搭一套 application 环境。
+ */
+function createDrawContextStub() {
+  const hoisted: any[] = [];
+  const interactiveGroup = {
+    id: '_interactive_group',
+    shadowRoot: {
+      add: (child: any): void => {
+        hoisted.push(child);
+      },
+      removeChild: (child: any): void => {
+        const index = hoisted.indexOf(child);
+        if (index >= 0) {
+          hoisted.splice(index, 1);
+        }
+      }
+    }
+  };
+  const interactiveLayer = {
+    getElementById: (id: string): any => (id === '_interactive_group' ? interactiveGroup : undefined),
+    add: (): void => undefined
+  };
+  return {
+    hoisted,
+    drawContext: {
+      stage: {
+        tryInitInteractiveLayer: (): void => undefined,
+        getLayer: (name: string): any => (name === '_builtin_interactive' ? interactiveLayer : undefined)
+      }
+    }
+  };
+}
+
+function expectSamePlacement(actual: any, expected: any) {
+  expect(actual.a).toBeCloseTo(expected.a);
+  expect(actual.b).toBeCloseTo(expected.b);
+  expect(actual.c).toBeCloseTo(expected.c);
+  expect(actual.d).toBeCloseTo(expected.d);
+  expect(actual.e).toBeCloseTo(expected.e);
+  expect(actual.f).toBeCloseTo(expected.f);
+}
+
+describe('interactive graphic bounds', () => {
+  test('keeps the hoisted clone aligned with the source graphic under a transformed parent', () => {
+    const parent = createGroup({ x: 100, y: 80 });
+    const circle = createCircle({ x: 150, y: 100, radius: 12, globalZIndex: 100 });
+    parent.add(circle);
+
+    const { hoisted, drawContext } = createDrawContextStub();
+    const handled = new InteractiveDrawItemInterceptorContribution().beforeSetInteractive(
+      circle as any,
+      {} as any,
+      drawContext as any,
+      {} as any
+    );
+
+    expect(handled).toBe(true);
+    expect(hoisted).toHaveLength(1);
+
+    // 克隆是绘制层级的占位，拾取的包围盒预筛读的也是它，所以必须和原图元落在同一处
+    expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
+  });
+
+  test('leaves the clone untouched when the source graphic has no parent', () => {
+    const circle = createCircle({ x: 150, y: 100, radius: 12, globalZIndex: 100 });
+
+    const { drawContext } = createDrawContextStub();
+    new InteractiveDrawItemInterceptorContribution().beforeSetInteractive(
+      circle as any,
+      {} as any,
+      drawContext as any,
+      {} as any
+    );
+
+    expect(circle.interactiveGraphic.attribute.postMatrix).toBeUndefined();
+    expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
+  });
+});

--- a/packages/vrender-core/__tests__/unit/render/interactive-graphic-bounds.test.ts
+++ b/packages/vrender-core/__tests__/unit/render/interactive-graphic-bounds.test.ts
@@ -110,18 +110,24 @@ describe('interactive graphic bounds', () => {
     expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
   });
 
-  test('accounts for the parent scroll that doUpdateGlobalMatrix applies after the local matrix', () => {
+  test('leaves the parent scroll out, because globalAABBBounds does not carry it either', () => {
     const parent = createGroup({ x: 100, y: 80, scrollX: 30, scrollY: 20 });
     const circle = createCircle({ x: 150, y: 100, radius: 12, globalZIndex: 100 });
     parent.add(circle);
 
     hoist(circle);
 
-    expectSamePlacement(circle.interactiveGraphic.globalTransMatrix, circle.globalTransMatrix);
+    // doUpdateGlobalMatrix 把 scroll 叠进 globalTransMatrix，globalAABBBounds 却不含它，
+    // 而拾取预筛读的是后者 —— 克隆要跟着 bounds 走，所以只补祖先变换、不补 scroll
+    const ancestor = parent.globalTransMatrix;
+    const placement = circle.interactiveGraphic.globalTransMatrix;
+    expect(placement.e).toBeCloseTo(ancestor.e + circle.transMatrix.e);
+    expect(placement.f).toBeCloseTo(ancestor.f + circle.transMatrix.f);
+    expect(placement.e).not.toBeCloseTo(circle.globalTransMatrix.e);
   });
 
-  test('handles a scaled ancestor, a source postMatrix and a parent scroll together', () => {
-    const parent = createGroup({ x: 100, y: 80, scaleX: 2, scaleY: 3, scrollX: 30, scrollY: 20 });
+  test('handles a scaled ancestor together with a source postMatrix and a rotated source', () => {
+    const parent = createGroup({ x: 100, y: 80, scaleX: 2, scaleY: 3 });
     const circle = createCircle({
       x: 150,
       y: 100,

--- a/packages/vrender-core/src/render/contributions/render/draw-interceptor.ts
+++ b/packages/vrender-core/src/render/contributions/render/draw-interceptor.ts
@@ -1,4 +1,4 @@
-import { AABBBounds } from '@visactor/vutils';
+import { AABBBounds, Matrix } from '@visactor/vutils';
 import { mat3Tomat4, multiplyMat4Mat4 } from '../../../common/matrix';
 import { createGraphic } from '../../../graphic/graphic-creator';
 import type {
@@ -17,6 +17,9 @@ import { draw3dItem } from '../../../common/3d-interceptor';
 
 // 拦截器
 export const DrawItemInterceptor = Symbol.for('DrawItemInterceptor');
+
+/** 挂在交互层克隆上的 postMatrix 缓存，避免每帧重新分配 */
+const INTERACTIVE_POST_MATRIX = '_interactivePostMatrix';
 
 // export class DefaultDrawItemInterceptor implements IDrawItemInterceptor {
 //   drawItem(graphic: IGraphic, renderService: IRenderService, params?: IGraphicRenderDrawParams): boolean {
@@ -277,6 +280,61 @@ export class InteractiveDrawItemInterceptorContribution implements IDrawItemInte
    * @param drawContribution
    * @param params
    */
+  /**
+   * 算出克隆的 postMatrix，让它落在原图元所在的位置上。
+   *
+   * 目标是 clone.globalTransMatrix === graphic.globalTransMatrix。克隆和原图元的属性一致，局部矩阵
+   * `L`（不含 postMatrix）相同，于是：
+   *   graphic.globalTransMatrix = P × (ownPost × L) × T(scroll)      —— 见 doUpdateGlobalMatrix
+   *   clone.globalTransMatrix   = clonePost × L
+   * 把中间的 scroll 平移左移出来（T 为纯平移，`own × T(s) × own⁻¹` 仍是平移，位移量即 own 的线性部分
+   * 作用在 s 上），两边约掉 L 即得：
+   *   clonePost = P × T(own · scroll) × ownPost
+   * 每帧复用挂在克隆上的同一个 Matrix，避免反复分配。
+   */
+  protected resolveInteractivePostMatrix(graphic: IGraphic, interactiveGraphic: IGraphic): Matrix | undefined {
+    const parent = graphic.parent;
+    // 没有祖先时克隆自身的 postMatrix 就已经是完整变换，保持原样
+    if (!parent) {
+      return graphic.attribute.postMatrix;
+    }
+    let matrix: Matrix = (interactiveGraphic as any)[INTERACTIVE_POST_MATRIX];
+    if (!matrix) {
+      matrix = new Matrix();
+      (interactiveGraphic as any)[INTERACTIVE_POST_MATRIX] = matrix;
+    }
+    const ancestorMatrix = (parent as IGroup).globalTransMatrix;
+    matrix.setValue(
+      ancestorMatrix.a,
+      ancestorMatrix.b,
+      ancestorMatrix.c,
+      ancestorMatrix.d,
+      ancestorMatrix.e,
+      ancestorMatrix.f
+    );
+    const { scrollX = 0, scrollY = 0 } = parent.attribute;
+    if (scrollX || scrollY) {
+      const ownMatrix = graphic.transMatrix;
+      matrix.translate(
+        ownMatrix.a * scrollX + ownMatrix.c * scrollY,
+        ownMatrix.b * scrollX + ownMatrix.d * scrollY
+      );
+    }
+    // 克隆是从原图元 clone 来的，自带原图元的 postMatrix，不能被祖先变换顶掉
+    const ownPostMatrix = graphic.attribute.postMatrix;
+    if (ownPostMatrix) {
+      matrix.multiply(
+        ownPostMatrix.a,
+        ownPostMatrix.b,
+        ownPostMatrix.c,
+        ownPostMatrix.d,
+        ownPostMatrix.e,
+        ownPostMatrix.f
+      );
+    }
+    return matrix;
+  }
+
   beforeSetInteractive(
     graphic: IGraphic,
     renderService: IRenderService,
@@ -295,12 +353,11 @@ export class InteractiveDrawItemInterceptorContribution implements IDrawItemInte
       // 克隆挂进交互层后就脱离了原图元的祖先链，只剩自身的局部变换。绘制由 beforeDrawInteractive 用
       // baseGraphic.parent.globalTransMatrix 手动补偿，但克隆自身的包围盒补不到，会整体少一个祖先变换；
       // pickGroup 的 insideGroup 预筛读的正是这个包围盒，落在偏移框外的图元会被整层跳过而拾取不到。
-      // postMatrix 合成在局部变换之外（见 Graphic.doUpdateLocalMatrix），正好等价于祖先链的贡献。
       interactiveGraphic.setAttributes(
         {
           globalZIndex: 0,
           zIndex: graphic.attribute.globalZIndex,
-          postMatrix: graphic.parent ? graphic.parent.globalTransMatrix.clone() : undefined
+          postMatrix: this.resolveInteractivePostMatrix(graphic, interactiveGraphic)
         },
         false,
         { skipUpdateCallback: true }

--- a/packages/vrender-core/src/render/contributions/render/draw-interceptor.ts
+++ b/packages/vrender-core/src/render/contributions/render/draw-interceptor.ts
@@ -281,15 +281,16 @@ export class InteractiveDrawItemInterceptorContribution implements IDrawItemInte
    * @param params
    */
   /**
-   * 算出克隆的 postMatrix，让它落在原图元所在的位置上。
+   * 算出克隆的 postMatrix，让它的包围盒落回原图元所在的位置。
    *
-   * 目标是 clone.globalTransMatrix === graphic.globalTransMatrix。克隆和原图元的属性一致，局部矩阵
-   * `L`（不含 postMatrix）相同，于是：
-   *   graphic.globalTransMatrix = P × (ownPost × L) × T(scroll)      —— 见 doUpdateGlobalMatrix
-   *   clone.globalTransMatrix   = clonePost × L
-   * 把中间的 scroll 平移左移出来（T 为纯平移，`own × T(s) × own⁻¹` 仍是平移，位移量即 own 的线性部分
-   * 作用在 s 上），两边约掉 L 即得：
-   *   clonePost = P × T(own · scroll) × ownPost
+   * 对齐的目标是 `globalAABBBounds` —— 拾取预筛读的就是它。克隆和原图元的属性一致，局部矩阵 `L`
+   * （不含 postMatrix）相同，所以只要把祖先贡献补在 `L` 之外即可：
+   *   clonePost = P × ownPost
+   *
+   * 注意这里刻意不带父级的 scroll。`doUpdateGlobalMatrix` 会把 scroll 叠进 `globalTransMatrix`，但
+   * `globalAABBBounds` 并不包含它（父级 `scrollX/scrollY` 为 30/20 时，普通图元的 matrix.e 是 180 而
+   * bounds 中心是 150），所以按 matrix 去对齐反而会把克隆的包围盒推出去一个 scroll。
+   *
    * 每帧复用挂在克隆上的同一个 Matrix，避免反复分配。
    */
   protected resolveInteractivePostMatrix(graphic: IGraphic, interactiveGraphic: IGraphic): Matrix | undefined {
@@ -312,14 +313,6 @@ export class InteractiveDrawItemInterceptorContribution implements IDrawItemInte
       ancestorMatrix.e,
       ancestorMatrix.f
     );
-    const { scrollX = 0, scrollY = 0 } = parent.attribute;
-    if (scrollX || scrollY) {
-      const ownMatrix = graphic.transMatrix;
-      matrix.translate(
-        ownMatrix.a * scrollX + ownMatrix.c * scrollY,
-        ownMatrix.b * scrollX + ownMatrix.d * scrollY
-      );
-    }
     // 克隆是从原图元 clone 来的，自带原图元的 postMatrix，不能被祖先变换顶掉
     const ownPostMatrix = graphic.attribute.postMatrix;
     if (ownPostMatrix) {

--- a/packages/vrender-core/src/render/contributions/render/draw-interceptor.ts
+++ b/packages/vrender-core/src/render/contributions/render/draw-interceptor.ts
@@ -292,11 +292,15 @@ export class InteractiveDrawItemInterceptorContribution implements IDrawItemInte
         interactiveGraphic.baseGraphic = graphic;
       }
       // 设置位置
-      // const m = graphic.globalTransMatrix;
+      // 克隆挂进交互层后就脱离了原图元的祖先链，只剩自身的局部变换。绘制由 beforeDrawInteractive 用
+      // baseGraphic.parent.globalTransMatrix 手动补偿，但克隆自身的包围盒补不到，会整体少一个祖先变换；
+      // pickGroup 的 insideGroup 预筛读的正是这个包围盒，落在偏移框外的图元会被整层跳过而拾取不到。
+      // postMatrix 合成在局部变换之外（见 Graphic.doUpdateLocalMatrix），正好等价于祖先链的贡献。
       interactiveGraphic.setAttributes(
         {
           globalZIndex: 0,
-          zIndex: graphic.attribute.globalZIndex
+          zIndex: graphic.attribute.globalZIndex,
+          postMatrix: graphic.parent ? graphic.parent.globalTransMatrix.clone() : undefined
         },
         false,
         { skipUpdateCallback: true }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

fix #2109

### 💡 Background and solution

The clone that `InteractiveDrawItemInterceptorContribution.beforeSetInteractive` hoists into `_builtin_interactive` only carried `globalZIndex` / `zIndex`, so it lost the transform its source inherits from its ancestors.

Drawing was unaffected, because `beforeDrawInteractive` renders the `baseGraphic` and re-applies the matrix by hand:

```ts
context.setTransformFromMatrix(baseGraphic.parent.globalTransMatrix, true);
```

But the clone's own geometry was never corrected, so its `globalAABBBounds` — and therefore the bounds of the shadow root, of `_interactive_group`, and of the whole interactive layer — ended up short by exactly that transform.

Picking reads those bounds. `DefaultPickService.pickGroup` gates traversal on them:

```ts
const insideGroup = group.AABBBounds.containsPoint(newPoint);
if (!insideGroup && !group.stage.camera) return result;
```

So whenever the real pointer position fell outside the shifted box, the entire interactive layer was skipped and the hoisted graphic was unreachable even though it was painted on top. Graphics that happened to fall inside the shifted box still picked correctly, which made it look intermittent — in a chart, data points near one edge of the plot area stopped responding to hover while the rest worked.

The fix gives the clone a `postMatrix` built from its source's parent global matrix. `postMatrix` composes outside the local transform (`Graphic.doUpdateLocalMatrix`), so it reproduces exactly what the ancestor chain contributes, and rendering is untouched since the draw path still goes through `baseGraphic`.

There was already a `// const m = graphic.globalTransMatrix;` left commented out at that spot, so this looks like it was on someone's radar.

Verified against the reproduction attached to the issue (a graphic with `globalZIndex` inside a translated group, occluded by a sibling group): `stage.pick` goes from returning the covering `rect` to returning the `circle`, and the clone's bounds become identical to the source's.

### 📝 Changelog

| Language | Changelog |
| -------- | --------- |
| 🇺🇸 English | Fix graphics hoisted with `globalZIndex` becoming unpickable when an ancestor carries a transform. |
| 🇨🇳 Chinese | 修复祖先带变换时，配置了 `globalZIndex` 的图元无法被拾取的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

Added `packages/vrender-core/__tests__/unit/render/interactive-graphic-bounds.test.ts`, which fails on `develop` (clone lands at `e = 150` instead of `250`) and passes with the fix. `tsc --noEmit` and eslint are clean for `vrender-core`.
