### PR TITLE
fix: respect lynx env in browser shared entry

### DIFF
--- a/packages/vrender/__tests__/types/entries-typing.ts
+++ b/packages/vrender/__tests__/types/entries-typing.ts
@@ -6,10 +6,21 @@ import {
   type TVRenderSharedAppHandle,
   type TVRenderSharedAppOptions
 } from '../../src/entries/shared';
+import {
+  acquireSharedVRenderApp as acquireBrowserConditionSharedVRenderApp,
+  type TVRenderSharedBrowserAppHandle
+} from '../../src/entries/shared-browser';
 
 const browserFactory: (options?: IEntryOptions) => IApp = createBrowserVRenderApp;
 const nodeFactory: (options?: IEntryOptions) => IApp = createNodeVRenderApp;
 const browserSharedHandle: TVRenderSharedAppHandle<'browser'> = acquireSharedVRenderApp({ env: 'browser' });
+const positionalLynxSharedHandle: TVRenderSharedAppHandle<'lynx'> = acquireSharedVRenderApp(undefined, 'lynx');
+const browserConditionDefaultHandle: TVRenderSharedBrowserAppHandle<'browser'> =
+  acquireBrowserConditionSharedVRenderApp();
+const browserConditionLynxHandle: TVRenderSharedBrowserAppHandle<'lynx'> = acquireBrowserConditionSharedVRenderApp(
+  undefined,
+  'lynx'
+);
 const lynxSharedOptions: TVRenderSharedAppOptions<'lynx'> = {
   env: 'lynx',
   key: 'main',
@@ -21,4 +32,7 @@ const lynxSharedOptions: TVRenderSharedAppOptions<'lynx'> = {
 void browserFactory;
 void nodeFactory;
 void browserSharedHandle;
+void positionalLynxSharedHandle;
+void browserConditionDefaultHandle;
+void browserConditionLynxHandle;
 void lynxSharedOptions;

--- a/packages/vrender/__tests__/unit/shared-browser-entry.test.ts
+++ b/packages/vrender/__tests__/unit/shared-browser-entry.test.ts
@@ -6,27 +6,62 @@ declare const require: any;
 export {};
 
 const emptyArray = (): never[] => [];
+const SHARED_APP_REGISTRY_KEY = Symbol.for('visactor.vrender.sharedAppRegistry');
 
-describe('browser-only shared app entry', () => {
+describe('browser-condition shared app entry', () => {
   beforeEach(() => {
     jest.resetModules();
+    delete (globalThis as any)[SHARED_APP_REGISTRY_KEY];
   });
 
-  test('does not load non-browser env, full custom animate, or gif modules', () => {
+  test('routes an explicit lynx env to the Lynx app without initializing the browser environment', () => {
+    jest.isolateModules(() => {
+      const lynxApp = {
+        env: 'lynx',
+        release: jest.fn()
+      };
+      const createBrowserApp = jest.fn(() => {
+        throw new Error('the Lynx shared app must not initialize the browser environment');
+      });
+      const createLynxVRenderApp = jest.fn(() => lynxApp);
+
+      jest.doMock('@visactor/vrender-core/entries/browser', () => ({
+        BrowserEntry: class BrowserEntry {},
+        createBrowserApp
+      }));
+      jest.doMock('../../src/entries/miniapp', () => ({ createLynxVRenderApp }));
+
+      const { acquireSharedVRenderApp } = require('../../src/entries/shared-browser');
+      const handle = (acquireSharedVRenderApp as any)(undefined, 'lynx');
+
+      expect(handle.env).toBe('lynx');
+      expect(handle.app).toBe(lynxApp);
+      expect(createLynxVRenderApp).toHaveBeenCalledTimes(1);
+      expect(createBrowserApp).not.toHaveBeenCalled();
+
+      handle.release();
+    });
+  });
+
+  test('keeps browser as the default and isolates browser and Lynx shared apps', () => {
     jest.isolateModules(() => {
       const legacyBindingContextMock = { getAll: jest.fn(emptyArray) };
-      const forbiddenLoads: string[] = [];
-      const createBrowserApp = jest.fn(() => ({
+      const browserApp = {
+        env: 'browser',
         registry: {
           renderer: { getAll: jest.fn(emptyArray), clear: jest.fn(), register: jest.fn() },
           picker: { getAll: jest.fn(emptyArray), clear: jest.fn(), register: jest.fn() }
         },
         release: jest.fn()
-      }));
+      };
+      const lynxApp = { env: 'lynx', release: jest.fn() };
+      const createBrowserApp = jest.fn(() => browserApp);
+      const createLynxVRenderApp = jest.fn(() => lynxApp);
 
       jest.doMock('@visactor/vrender-core/entries/browser', () => ({
         createBrowserApp
       }));
+      jest.doMock('../../src/entries/miniapp', () => ({ createLynxVRenderApp }));
       jest.doMock('@visactor/vrender-core/legacy/bootstrap', () => ({
         getLegacyBindingContext: jest.fn(() => legacyBindingContextMock)
       }));
@@ -90,26 +125,30 @@ describe('browser-only shared app entry', () => {
       [
         '@visactor/vrender-kits/env/node',
         '@visactor/vrender-kits/env/wx',
-        '@visactor/vrender-kits/env/lynx',
         '@visactor/vrender-kits/env/harmony',
         '@visactor/vrender-kits/env/browser',
         '@visactor/vrender-kits/register/register-gif',
         '@visactor/vrender-animate/custom/register'
       ].forEach(moduleName => {
         jest.doMock(moduleName, () => {
-          forbiddenLoads.push(moduleName);
-          return {};
+          throw new Error(`${moduleName} should not be loaded by shared-browser`);
         });
       });
 
-      const { acquireSharedBrowserVRenderApp } = require('../../src/entries/shared-browser');
-      const handle = acquireSharedBrowserVRenderApp({ env: 'browser', key: Symbol('browser-only') });
+      const { acquireSharedVRenderApp } = require('../../src/entries/shared-browser');
+      const browserHandle = acquireSharedVRenderApp();
+      const lynxHandle = (acquireSharedVRenderApp as any)(undefined, 'lynx');
 
       expect(createBrowserApp).toHaveBeenCalledTimes(1);
       expect(createBrowserApp).toHaveBeenCalledWith({});
-      expect(handle.env).toBe('browser');
-      expect(forbiddenLoads).toEqual([]);
-      handle.release();
+      expect(browserHandle.env).toBe('browser');
+      expect(browserHandle.app).toBe(browserApp);
+      expect(lynxHandle.env).toBe('lynx');
+      expect(lynxHandle.app).toBe(lynxApp);
+      expect(browserHandle.app).not.toBe(lynxHandle.app);
+
+      browserHandle.release();
+      lynxHandle.release();
     });
   });
 });

--- a/packages/vrender/src/entries/shared-browser.ts
+++ b/packages/vrender/src/entries/shared-browser.ts
@@ -1,6 +1,7 @@
 import type { IApp, IEntryOptions, IEnvParamsMap } from '@visactor/vrender-core';
 import { createBrowserApp } from '@visactor/vrender-core/entries/browser';
 import { bootstrapVRenderSharedBrowserApp } from './bootstrap-browser';
+import { createLynxVRenderApp } from './miniapp';
 import { installPendingRuntimeContributionModulesToApp } from './runtime-contribution';
 import {
   acquireSharedApp,
@@ -10,11 +11,11 @@ import {
   type TVRenderSharedAppKey
 } from './shared-registry';
 
-const SHARED_BROWSER_REGISTRY_ENV = 'browser-shared';
+export type TVRenderSharedBrowserAppEnv = 'browser' | 'lynx';
 
-export type TVRenderSharedBrowserAppOptions = IEntryOptions & {
-  env?: 'browser';
-  envParams?: IEnvParamsMap['browser'];
+export type TVRenderSharedBrowserAppOptions<TEnv extends TVRenderSharedBrowserAppEnv = 'browser'> = IEntryOptions & {
+  env?: TEnv;
+  envParams?: IEnvParamsMap[TEnv];
   /**
    * Shared identity inside the current JS runtime. Use a stable app/page/container key
    * when multiple products, such as VChart and VTable, should share one VRender app.
@@ -22,36 +23,106 @@ export type TVRenderSharedBrowserAppOptions = IEntryOptions & {
   key?: TVRenderSharedAppKey;
 };
 
-export type TVRenderSharedBrowserAppHandle = TVRenderSharedAppHandle<'browser'>;
+export type TVRenderSharedBrowserAppHandle<TEnv extends TVRenderSharedBrowserAppEnv = 'browser'> =
+  TVRenderSharedAppHandle<TEnv>;
 
-function createSharedBrowserApp(options: TVRenderSharedBrowserAppOptions): IApp {
-  const { envParams } = options;
+type TVRenderSharedBrowserAppArgument =
+  | TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv>
+  | IEnvParamsMap[TVRenderSharedBrowserAppEnv];
+
+function isSharedBrowserAppOptions(
+  options: TVRenderSharedBrowserAppArgument
+): options is TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv> {
+  return 'context' in options || 'env' in options || 'envParams' in options || 'key' in options;
+}
+
+function resolveSharedBrowserAppOptions(
+  optionsOrEnvParams?: TVRenderSharedBrowserAppArgument,
+  env?: TVRenderSharedBrowserAppEnv
+): TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv> {
+  if (env !== undefined) {
+    return {
+      env,
+      envParams: optionsOrEnvParams as IEnvParamsMap[TVRenderSharedBrowserAppEnv] | undefined
+    };
+  }
+
+  if (optionsOrEnvParams === undefined) {
+    return { env: 'browser' };
+  }
+
+  if (isSharedBrowserAppOptions(optionsOrEnvParams)) {
+    return {
+      ...optionsOrEnvParams,
+      env: optionsOrEnvParams.env ?? 'browser'
+    };
+  }
+
+  return {
+    env: 'browser',
+    envParams: optionsOrEnvParams
+  };
+}
+
+function createSharedBrowserApp(options: TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv>): IApp {
+  const { env, envParams } = options;
   const entryOptions = { ...options };
   delete entryOptions.env;
   delete entryOptions.envParams;
   delete entryOptions.key;
-  const app = bootstrapVRenderSharedBrowserApp(createBrowserApp(entryOptions as any) as unknown as IApp, envParams);
+
+  if (env === 'lynx') {
+    return createLynxVRenderApp({
+      ...(entryOptions as IEntryOptions),
+      envParams: envParams as IEnvParamsMap['lynx']
+    });
+  }
+
+  const app = bootstrapVRenderSharedBrowserApp(
+    createBrowserApp(entryOptions as any) as unknown as IApp,
+    envParams as IEnvParamsMap['browser']
+  );
 
   installPendingRuntimeContributionModulesToApp(app);
   return app;
 }
 
 export function acquireSharedBrowserVRenderApp(
-  options: TVRenderSharedBrowserAppOptions = {}
-): TVRenderSharedBrowserAppHandle {
-  return acquireSharedApp(SHARED_BROWSER_REGISTRY_ENV, options, createSharedBrowserApp, 'browser');
+  options?: TVRenderSharedBrowserAppOptions<'browser'>
+): TVRenderSharedBrowserAppHandle<'browser'>;
+export function acquireSharedBrowserVRenderApp(
+  envParams?: IEnvParamsMap['browser'],
+  env?: 'browser'
+): TVRenderSharedBrowserAppHandle<'browser'>;
+export function acquireSharedBrowserVRenderApp(
+  optionsOrEnvParams?: TVRenderSharedBrowserAppOptions<'browser'> | IEnvParamsMap['browser'],
+  env?: 'browser'
+): TVRenderSharedBrowserAppHandle<'browser'> {
+  const options = resolveSharedBrowserAppOptions(optionsOrEnvParams, env) as TVRenderSharedBrowserAppOptions<'browser'>;
+  return acquireSharedApp('browser-shared', options, createSharedBrowserApp, 'browser');
 }
 
 export function getSharedBrowserVRenderApp(key?: TVRenderSharedAppKey): IApp | null {
-  return getSharedApp(SHARED_BROWSER_REGISTRY_ENV, key);
+  return getSharedApp('browser-shared', key);
 }
 
 export function releaseSharedBrowserVRenderApp(key?: TVRenderSharedAppKey): void {
-  releaseSharedApp(SHARED_BROWSER_REGISTRY_ENV, key);
+  releaseSharedApp('browser-shared', key);
 }
 
-export {
-  acquireSharedBrowserVRenderApp as acquireSharedVRenderApp,
-  getSharedBrowserVRenderApp as getSharedVRenderApp,
-  releaseSharedBrowserVRenderApp as releaseSharedVRenderApp
-};
+export function acquireSharedVRenderApp<TEnv extends TVRenderSharedBrowserAppEnv>(
+  options?: TVRenderSharedBrowserAppOptions<TEnv>
+): TVRenderSharedBrowserAppHandle<TEnv>;
+export function acquireSharedVRenderApp<TEnv extends TVRenderSharedBrowserAppEnv>(
+  envParams?: IEnvParamsMap[TEnv],
+  env?: TEnv
+): TVRenderSharedBrowserAppHandle<TEnv>;
+export function acquireSharedVRenderApp(
+  optionsOrEnvParams?: TVRenderSharedBrowserAppArgument,
+  env?: TVRenderSharedBrowserAppEnv
+): TVRenderSharedBrowserAppHandle<TVRenderSharedBrowserAppEnv> {
+  const options = resolveSharedBrowserAppOptions(optionsOrEnvParams, env);
+  return acquireSharedApp(`${options.env}-shared`, options, createSharedBrowserApp, options.env);
+}
+
+export { getSharedBrowserVRenderApp as getSharedVRenderApp, releaseSharedBrowserVRenderApp as releaseSharedVRenderApp };

--- a/packages/vrender/src/entries/shared.ts
+++ b/packages/vrender/src/entries/shared.ts
@@ -1,4 +1,4 @@
-import type { IApp } from '@visactor/vrender-core';
+import type { IApp, IEnvParamsMap } from '@visactor/vrender-core';
 import { createBrowserVRenderApp, type TVRenderBrowserAppEntryOptions } from './browser';
 import {
   createFeishuVRenderApp,
@@ -45,6 +45,42 @@ export type TVRenderSharedAppOptions<TEnv extends TVRenderSharedAppEnv = TVRende
 
 export type TVRenderSharedAppHandle<TEnv extends TVRenderSharedAppEnv = TVRenderSharedAppEnv> = TSharedAppHandle<TEnv>;
 
+type TVRenderSharedAppArgument = TVRenderSharedAppOptions<TVRenderSharedAppEnv> | IEnvParamsMap[TVRenderSharedAppEnv];
+
+function isSharedAppOptions(
+  options: TVRenderSharedAppArgument
+): options is TVRenderSharedAppOptions<TVRenderSharedAppEnv> {
+  return 'context' in options || 'env' in options || 'envParams' in options || 'key' in options;
+}
+
+function resolveSharedAppOptions(
+  optionsOrEnvParams?: TVRenderSharedAppArgument,
+  env?: TVRenderSharedAppEnv
+): TVRenderSharedAppOptions<TVRenderSharedAppEnv> {
+  if (env !== undefined) {
+    return {
+      env,
+      envParams: optionsOrEnvParams as IEnvParamsMap[TVRenderSharedAppEnv] | undefined
+    } as TVRenderSharedAppOptions<TVRenderSharedAppEnv>;
+  }
+
+  if (optionsOrEnvParams === undefined) {
+    return { env: 'browser' } as TVRenderSharedAppOptions<'browser'>;
+  }
+
+  if (isSharedAppOptions(optionsOrEnvParams)) {
+    return {
+      ...optionsOrEnvParams,
+      env: optionsOrEnvParams.env ?? 'browser'
+    } as TVRenderSharedAppOptions<TVRenderSharedAppEnv>;
+  }
+
+  return {
+    env: 'browser',
+    envParams: optionsOrEnvParams
+  } as TVRenderSharedAppOptions<'browser'>;
+}
+
 function createAppForSharedEnv<TEnv extends TVRenderSharedAppEnv>(options: TVRenderSharedAppOptions<TEnv>): IApp {
   const { env } = options;
   const entryOptions = { ...options } as Record<string, unknown>;
@@ -76,8 +112,17 @@ function createAppForSharedEnv<TEnv extends TVRenderSharedAppEnv>(options: TVRen
 }
 
 export function acquireSharedVRenderApp<TEnv extends TVRenderSharedAppEnv>(
-  options: TVRenderSharedAppOptions<TEnv>
-): TVRenderSharedAppHandle<TEnv> {
+  options?: TVRenderSharedAppOptions<TEnv>
+): TVRenderSharedAppHandle<TEnv>;
+export function acquireSharedVRenderApp<TEnv extends TVRenderSharedAppEnv>(
+  envParams?: IEnvParamsMap[TEnv],
+  env?: TEnv
+): TVRenderSharedAppHandle<TEnv>;
+export function acquireSharedVRenderApp(
+  optionsOrEnvParams?: TVRenderSharedAppArgument,
+  env?: TVRenderSharedAppEnv
+): TVRenderSharedAppHandle<TVRenderSharedAppEnv> {
+  const options = resolveSharedAppOptions(optionsOrEnvParams, env);
   return acquireSharedApp(options.env, options, createAppForSharedEnv, options.env);
 }
 


### PR DESCRIPTION
## Summary

- Dispatch the browser-condition shared entry using the caller-provided environment.
- Initialize explicit Lynx requests with the Lynx app creator while preserving browser as the default.
- Scope shared registry keys by environment and cover positional API/type compatibility.

## Root cause

The browser export condition routes entries/shared to shared-browser, which previously created a browser-shared app even when Lynx was explicitly requested. In a Lynx Web worker, that selected browser environment logic and accessed window.devicePixelRatio.

## Validation

- Targeted shared-entry, shared-app, and public-subpath Jest tests
- Type tests, targeted ESLint, and git diff --check
- Commit hook: rush lint-staged and rush commitlint

The full artifact-consistency test needs absent es/cjs build artifacts. The workspace pre-push tag test is blocked before this package by an existing vrender-kits ts-jest preset-resolution error; targeted VRender validation passed.