### PR TITLE
fix(core): 隔离不同版本的 Graphic 类

### DIFF
--- a/packages/vrender-core/__tests__/unit/graphic/graphic-factory-migration.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/graphic-factory-migration.test.ts
@@ -14,16 +14,30 @@ class GraphicStub {
   constructor(public readonly attribute: Record<string, unknown>) {}
 }
 
+class OtherGraphicStub extends GraphicStub {}
+
 describe('graphic factory migration', () => {
-  test('graphic registry should use realm-level shared state for duplicated ESM entry evaluation', () => {
-    registerGraphic('realm-shared-stub', GraphicStub as any);
+  test('graphic registry should stay module-local for duplicated module evaluation', () => {
+    const slot = Symbol.for('@visactor/vrender-core/graphic-registry');
+    delete (globalThis as any)[slot];
 
-    const registryState = (globalThis as any)[Symbol.for('@visactor/vrender-core/graphic-registry')];
+    jest.resetModules();
+    const firstRegistry = require('../../../src/graphic/graphic-registry');
+    firstRegistry.registerGraphic('module-local-stub', GraphicStub as any);
 
-    expect(registryState).toBeDefined();
-    expect(registryState.graphicCreator).toBe(graphicCreator);
-    expect(registryState.graphicFactory.create('realm-shared-stub', { x: 1 })).toBeInstanceOf(GraphicStub);
-    expect(createGraphic('realm-shared-stub', { x: 2 })).toBeInstanceOf(GraphicStub);
+    jest.resetModules();
+    const secondRegistry = require('../../../src/graphic/graphic-registry');
+    secondRegistry.registerGraphic('module-local-stub', OtherGraphicStub as any);
+
+    try {
+      expect(secondRegistry.graphicCreator).not.toBe(firstRegistry.graphicCreator);
+      expect(firstRegistry.createGraphic('module-local-stub', { x: 1 })).toBeInstanceOf(GraphicStub);
+      expect(firstRegistry.createGraphic('module-local-stub', { x: 1 })).not.toBeInstanceOf(OtherGraphicStub);
+      expect(secondRegistry.createGraphic('module-local-stub', { x: 2 })).toBeInstanceOf(OtherGraphicStub);
+      expect(Object.prototype.hasOwnProperty.call(globalThis, slot)).toBe(false);
+    } finally {
+      delete (globalThis as any)[slot];
+    }
   });
 
   test('Graphic class should stay module-local for duplicated module evaluation', () => {

--- a/packages/vrender-core/__tests__/unit/graphic/graphic-factory-migration.test.ts
+++ b/packages/vrender-core/__tests__/unit/graphic/graphic-factory-migration.test.ts
@@ -1,13 +1,14 @@
 import type { IRectGraphicAttribute } from '../../../src/interface';
 import { createGraphic, graphicCreator, registerGraphic } from '../../../src/graphic';
 import { Arc3d } from '../../../src/graphic/arc3d';
-import { Graphic } from '../../../src/graphic/base';
 import { DefaultGraphicService } from '../../../src/graphic/graphic-service/graphic-service';
 import { Group } from '../../../src/graphic/group';
 import { Rect } from '../../../src/graphic/rect';
 import { registerArc3dGraphic } from '../../../src/register/register-arc3d';
 import { registerGroupGraphic } from '../../../src/register/register-group';
 import { registerRectGraphic } from '../../../src/register/register-rect';
+
+declare const require: any;
 
 class GraphicStub {
   constructor(public readonly attribute: Record<string, unknown>) {}
@@ -25,18 +26,24 @@ describe('graphic factory migration', () => {
     expect(createGraphic('realm-shared-stub', { x: 2 })).toBeInstanceOf(GraphicStub);
   });
 
-  test('Graphic class should use realm-level shared state for duplicated ESM entry evaluation', () => {
-    registerGroupGraphic();
-    registerArc3dGraphic();
+  test('Graphic class should stay module-local for duplicated module evaluation', () => {
+    const slot = Symbol.for('@visactor/vrender-core/graphic-class');
+    delete (globalThis as any)[slot];
 
-    const classState = (globalThis as any)[Symbol.for('@visactor/vrender-core/graphic-class')];
-    const group = createGraphic('group', {});
-    const arc3d = createGraphic('arc3d', {});
+    let firstGraphic: unknown = null;
+    let secondGraphic: unknown = null;
 
-    expect(classState).toBeDefined();
-    expect(classState.Graphic).toBe(Graphic);
-    expect(group).toBeInstanceOf(classState.Graphic);
-    expect(arc3d).toBeInstanceOf(classState.Graphic);
+    jest.resetModules();
+    firstGraphic = require('../../../src/graphic/graphic').Graphic;
+    jest.resetModules();
+    secondGraphic = require('../../../src/graphic/graphic').Graphic;
+
+    try {
+      expect(secondGraphic).not.toBe(firstGraphic);
+      expect(Object.prototype.hasOwnProperty.call(globalThis, slot)).toBe(false);
+    } finally {
+      delete (globalThis as any)[slot];
+    }
   });
 
   test('registerGraphic should register creators for createGraphic', () => {

--- a/packages/vrender-core/src/graphic/graphic-registry.ts
+++ b/packages/vrender-core/src/graphic/graphic-registry.ts
@@ -106,17 +106,11 @@ function createGraphicRegistryState(): IGraphicRegistryState {
   };
 }
 
+const sharedGraphicRegistry = createGraphicRegistryState();
+
 export function getGraphicRegistryState(): IGraphicRegistryState {
-  const scope = globalThis as typeof globalThis & { [GRAPHIC_REGISTRY_SYMBOL]?: IGraphicRegistryState };
-
-  if (!scope[GRAPHIC_REGISTRY_SYMBOL]) {
-    scope[GRAPHIC_REGISTRY_SYMBOL] = createGraphicRegistryState();
-  }
-
-  return scope[GRAPHIC_REGISTRY_SYMBOL] as IGraphicRegistryState;
+  return sharedGraphicRegistry;
 }
-
-const sharedGraphicRegistry = getGraphicRegistryState();
 
 export const graphicCreator = sharedGraphicRegistry.graphicCreator;
 

--- a/packages/vrender-core/src/graphic/graphic.ts
+++ b/packages/vrender-core/src/graphic/graphic.ts
@@ -306,7 +306,7 @@ export const NOWORK_ANIMATE_ATTR = {
  * 3. 所有节点的transform修改，或者globalTransform修改，都会下发到自己的shadowRoot上
  */
 
-abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraphicAttribute>>
+export abstract class Graphic<T extends Partial<IGraphicAttribute> = Partial<IGraphicAttribute>>
   extends Node
   implements IGraphic<T>, IAnimateTarget
 {
@@ -3229,31 +3229,6 @@ abstract class GraphicImpl<T extends Partial<IGraphicAttribute> = Partial<IGraph
     return null;
   }
 }
-
-export type Graphic<T extends Partial<IGraphicAttribute> = Partial<IGraphicAttribute>> = GraphicImpl<T>;
-
-export const GRAPHIC_CLASS_SYMBOL = Symbol.for('@visactor/vrender-core/graphic-class');
-
-export interface IGraphicClassState {
-  Graphic: typeof GraphicImpl;
-}
-
-function createGraphicClassState(): IGraphicClassState {
-  return {
-    Graphic: GraphicImpl
-  };
-}
-
-export function getGraphicClassState(): IGraphicClassState {
-  const globalScope = globalThis as typeof globalThis & {
-    [GRAPHIC_CLASS_SYMBOL]?: IGraphicClassState;
-  };
-
-  globalScope[GRAPHIC_CLASS_SYMBOL] ??= createGraphicClassState();
-  return globalScope[GRAPHIC_CLASS_SYMBOL];
-}
-
-export const Graphic = getGraphicClassState().Graphic;
 
 Graphic.mixin(EventTarget);
 


### PR DESCRIPTION
## 变更

- 移除 Graphic 类在 globalThis/window 上的跨 bundle 全局单例，改为模块/版本内隔离
- 移除 graphicCreator 与 graphicFactory 在 globalThis/window 上的跨 bundle共享状态，避免后加载版本覆盖先加载版本的图元构造器
- 保留现有导出接口，并补充重复模块加载回归测试

## 用户反馈核验

- 已复现：1.1.7 与新版本同时存在时，全局 graphic registry 会导致旧版本 creator 创建出新版本 Graphic 实例
- 已确认：原生 EventManager hover 直接读取监听器，不经过 Graphic.dispatchEvent，因此反馈中的 hover 必然失效并不准确
- 已确认：跨版本事件对象直接传给 Graphic.dispatchEvent 仍会触发 instanceof 保护；隔离 registry 可消除反馈所述的跨版本实例来源

## 验证

- vrender-core 全量测试：109 suites passed，637 tests passed
- Rush 7 个 package 全量测试通过
- Rush 7 个 package 全量构建通过
- 1.1.7 与本分支构建产物混合加载验证通过：creator、factory 与实例保持版本隔离
- ESLint、Prettier、git diff --check 通过