### PR TITLE
fix(entries): 隔离 Browser 与 Lynx 共享入口

### DIFF
--- a/docs/agent/VRENDER_PACKAGE_MAP.md
+++ b/docs/agent/VRENDER_PACKAGE_MAP.md
@@ -8,7 +8,7 @@
 - 分层：上层整合包。
 - root entry：`packages/vrender/src/index.ts`
 - 主要职责：聚合导出 `@visactor/vrender-core`、`@visactor/vrender-kits`、`@visactor/vrender-animate`、`@visactor/vrender-components`，提供 app-scoped entries，并保留 legacy `createStage`。
-- 重要 exports：`.`、`./entries`、`./entries/browser`、`./entries/node`、`./entries/miniapp`、`./entries/shared`、`./entries/shared-browser`、`./entries/shared-browser-lite`。
+- 重要 exports：`.`、`./entries`、`./entries/browser`、`./entries/node`、`./entries/miniapp`、`./entries/shared`、`./entries/shared-browser`、`./entries/shared-browser-lite`；`./entries/shared` 另有 `lynx` 条件目标。
 - 运行时注册副作用：`sideEffects: true`。入口 bootstrap 会安装 env、graphics、pickers、plugins、animate，并同步 legacy render/picker binding。
 - 常见调用方：VChart、VTable、普通 VRender 用户、React 绑定层。
 - 改动风险：入口默认装配、shared app 引用计数、legacy 兼容、browser condition、Node canvas envParams。
@@ -21,7 +21,7 @@
 - 分层：核心渲染底座。
 - root entry：`packages/vrender-core/src/index.ts`
 - 主要职责：Graphic、Stage、Layer、render/picker service、event、state/shared-state、registry、factory、application、entries/app context。
-- 重要 exports：`.`、`./application`、`./container`、`./entries/browser`、`./entries/runtime-installer`、`./graphic/creator`、`./graphic/base`、`./graphic/group`、`./register/graphic`、`./render/*`、`./picker/constants`、`./path`、`./svg`、`./text`。
+- 重要 exports：`.`、`./application`、`./container`、`./entries/browser`、`./entries/miniapp`、`./entries/runtime-installer`、`./graphic/creator`、`./graphic/base`、`./graphic/group`、`./register/graphic`、`./render/*`、`./picker/constants`、`./path`、`./svg`、`./text`。
 - 运行时注册副作用：`sideEffects` 只列 `src/modules.ts` 及构建产物，顶层导出本身不应承担完整 env 装配。
 - 常见调用方：`vrender-kits`、`vrender-animate`、`vrender-components`、`vrender`。
 - 改动风险：高。图元属性、bounds、状态、render/picker 绑定和 legacy/app-scoped 双路径都可能跨包回归。
@@ -34,7 +34,7 @@
 - 分层：运行时装配与环境适配层。
 - root entry：`packages/vrender-kits/src/index.ts`，Node require 入口为构建后的 `index-node`。
 - 主要职责：env、canvas/window contribution、register/register-*、installers、browser/math picker、event extension、JSX/react-tree、gif/lottie/dynamicTexture。
-- 重要 exports：`.`、`./env/*`、`./event/extension/*`、`./installers/app`、`./installers/browser`、`./installers/browser-lite`、`./installers/graphics`、`./installers/graphics-lite`、`./register/register-*`、`./jsx/graphicType`、`./tools/dynamicTexture/effect`。
+- 重要 exports：`.`、`./env/*`、`./event/extension/*`、`./installers/app`、`./installers/browser`、`./installers/browser-lite`、`./installers/lynx`、`./installers/graphics`、`./installers/graphics-lite`、`./register/register-*`、`./jsx/graphicType`、`./tools/dynamicTexture/effect`。
 - 运行时注册副作用：`sideEffects: false`。注册函数/installer 显式调用后才装配。
 - 常见调用方：`@visactor/vrender` entries、按需装配调用方、测试 harness。
 - 改动风险：env 互相污染、picker/render binding 缺失、browser-lite 与 full 装配不一致、多端 canvas/window 参数边界。

--- a/docs/agent/VRENDER_RUNTIME_AND_ENTRIES.md
+++ b/docs/agent/VRENDER_RUNTIME_AND_ENTRIES.md
@@ -21,8 +21,10 @@ core entries 只创建 app/context，不做默认图元、环境、picker、动�
 - `browser.ts`：`createBrowserVRenderApp(options)`。
 - `node.ts`：`createNodeVRenderApp(options)`。
 - `miniapp.ts`：`createTaroVRenderApp`、`createFeishuVRenderApp`、`createTTVRenderApp`、`createWxVRenderApp`、`createLynxVRenderApp`、`createHarmonyVRenderApp`。
+- `lynx.ts`：不经过多环境 bootstrap 的 `createLynxVRenderApp` 窄入口。
 - `shared.ts`：按 `env` 创建/复用 shared app。
 - `shared-browser.ts`：browser shared full 装配。
+- `shared-lynx.ts`：Lynx shared full 装配。
 - `shared-browser-lite.ts`：browser shared lite 装配。
 - `shared-registry.ts`：`globalThis` 上的 shared app registry 与引用计数。
 - `bootstrap*.ts`：root package 默认装配逻辑。
@@ -63,10 +65,11 @@ Stage 创建属于 app：
 - handle 的 `release()` 减少引用计数；最后一个 handle 释放后 app 释放。
 - 直接调用 shared app 的 `app.release()` 会走同一 record release 逻辑。
 
-## `shared` / `shared-browser` / `shared-browser-lite`
+## `shared` / `shared-browser` / `shared-lynx` / `shared-browser-lite`
 
-- `./entries/shared`：通用 env shared entry，支持 `browser`、`node`、`taro`、`feishu`、`tt`、`wx`、`lynx`、`harmony`。package exports 中 browser condition 会路由到 `shared-browser.js`。
+- `./entries/shared`：通用 env shared entry，支持 `browser`、`node`、`taro`、`feishu`、`tt`、`wx`、`lynx`、`harmony`。package exports 中 `browser` condition 路由到 `shared-browser.js`，`lynx` condition 路由到 `shared-lynx.js`。
 - `./entries/shared-browser`：只面向 browser，使用 registry env `browser-shared`，走 standard/full browser bootstrap。
+- `lynx` condition 对应的 `shared-lynx`：只面向 Lynx，使用 registry env `lynx-shared`，只装配 Lynx env、math picker 和 full graphics。
 - `./entries/shared-browser-lite`：只面向 browser，使用 registry env `browser-lite-shared`，走 lite bootstrap。
 
 不要把 `shared-browser-lite` 当作 full 默认装配；它只安装 lite 图元和 lite picker 集合。
@@ -123,7 +126,7 @@ root package bootstrap 为“上层默认使用”服务；core entries 是更�
 
 ## 改 Entries 的高风险点
 
-- package exports 的 browser condition：`./entries/shared` 在 browser 下指向 `shared-browser`。
+- package exports 的条件顺序：`./entries/shared` 的 `lynx` 必须位于 `browser` 之前，分别指向 `shared-lynx`、`shared-browser`，避免 Rspeedy 同时启用两种 condition 时误选 browser。
 - shared app registry key：`browser-shared`、`browser-lite-shared` 与通用 env registry 不相同。
 - bootstrap idempotency：`BOOTSTRAP_STATE` 防止同一 app 重复 bootstrap。
 - legacy sync：`syncLegacyRenderersToApp` / `syncLegacyPickersToApp` 合并 app registry 和 legacy binding。
@@ -136,6 +139,8 @@ root package bootstrap 为“上层默认使用”服务；core entries 是更�
 - root entries：`packages/vrender/__tests__/unit/entries.test.ts`
 - shared app：`packages/vrender/__tests__/unit/shared-app.test.ts`
 - shared browser：`packages/vrender/__tests__/unit/shared-browser-entry.test.ts`
+- shared Lynx：`packages/vrender/__tests__/unit/shared-lynx-entry.test.ts`
+- shared 环境隔离：`packages/vrender/__tests__/unit/shared-entry-environment-isolation.test.ts`
 - shared browser lite：`packages/vrender/__tests__/unit/shared-browser-lite-entry.test.ts`
 - app bootstrap binding：`packages/vrender/__tests__/unit/app-bootstrap-binding.test.ts`
 - node runtime：`packages/vrender/__tests__/unit/node-app-runtime.test.ts`

--- a/docs/agent/VRENDER_TEST_AND_VERIFICATION.md
+++ b/docs/agent/VRENDER_TEST_AND_VERIFICATION.md
@@ -130,6 +130,8 @@ root：
 - `packages/vrender/__tests__/unit/entries.test.ts`
 - `packages/vrender/__tests__/unit/shared-app.test.ts`
 - `packages/vrender/__tests__/unit/shared-browser-entry.test.ts`
+- `packages/vrender/__tests__/unit/shared-lynx-entry.test.ts`
+- `packages/vrender/__tests__/unit/shared-entry-environment-isolation.test.ts`
 - `packages/vrender/__tests__/unit/shared-browser-lite-entry.test.ts`
 - `packages/vrender/__tests__/unit/app-bootstrap-binding.test.ts`
 - `packages/vrender/__tests__/unit/node-app-runtime.test.ts`

--- a/docs/refactor/bundle-size/VRENDER_IMPORT_AND_ENTRY_AUDIT.md
+++ b/docs/refactor/bundle-size/VRENDER_IMPORT_AND_ENTRY_AUDIT.md
@@ -36,7 +36,7 @@ VRender 当前已经有 app-scoped entries 和 lite shared browser 入口，但 
 | root `.` | `packages/vrender/src/index.ts` 导出 `@visactor/vrender-core`、kits、animate、components、entries、legacy `createStage` | full 兼容入口，不能改成 lite；root import 本身是最高风险 | bundle 对比 root import vs subpath import；跑 root import 不 bootstrap 的 existing tests |
 | `./entries` | `packages/vrender/src/entries/index.ts` 导出 browser / miniapp / node / shared | entry barrel，非最窄入口 | analyzer 验证是否把 miniapp/node 静态带入 |
 | `./entries/browser` | `createBrowserVRenderApp`，走 `bootstrapVRenderBrowserApp` | full browser app，默认行为不能破坏 | `packages/vrender/__tests__/unit/entries.test.ts` |
-| `./entries/shared` | browser condition 指向 `shared-browser`；普通 import 走通用 `shared.ts`，静态导入 browser/node/miniapp creators | browser bundler 配置正确时较窄；条件不生效会变宽 | browser/non-browser resolve 条件各打一遍 |
+| `./entries/shared` | `lynx` / `browser` condition 分别指向 `shared-lynx` / `shared-browser`；普通 import 走通用 `shared.ts` | 对应 bundler condition 生效时只装配目标环境；条件不生效会变宽 | lynx/browser/non-browser resolve 条件各打一遍 |
 | `./entries/shared-browser` | 只面向 browser，走 full shared browser bootstrap | full shared browser 标准入口 | `shared-browser-entry.test.ts` |
 | `./entries/shared-browser-lite` | 只面向 browser，走 lite bootstrap | lite 候选入口，不能替代 full 默认 | `shared-browser-lite-entry.test.ts` |
 

--- a/packages/vrender-core/__tests__/unit/public-subpath-exports.test.ts
+++ b/packages/vrender-core/__tests__/unit/public-subpath-exports.test.ts
@@ -48,6 +48,7 @@ const expectedExports: ExpectedSubpath[] = [
   { subpath: './render/draw-interceptor', source: 'src/render/contributions/render/draw-interceptor.ts' },
   { subpath: './render/symbol', source: 'src/render/contributions/render/symbol.ts' },
   { subpath: './entries/browser', source: 'src/entries/browser.ts' },
+  { subpath: './entries/miniapp', source: 'src/entries/miniapp.ts' },
   { subpath: './entries/runtime-installer', source: 'src/entries/runtime-installer.ts' }
 ];
 

--- a/packages/vrender-core/package.json
+++ b/packages/vrender-core/package.json
@@ -20,6 +20,7 @@
       "constants": ["es/constants.d.ts"],
       "container": ["es/container.d.ts"],
       "entries/browser": ["es/entries/browser.d.ts"],
+      "entries/miniapp": ["es/entries/miniapp.d.ts"],
       "entries/runtime-installer": ["es/entries/runtime-installer.d.ts"],
       "env": ["es/env.d.ts"],
       "event/constant": ["es/event/public-constant.d.ts"],
@@ -150,6 +151,11 @@
       "types": "./es/entries/browser.d.ts",
       "import": "./es/entries/browser.js",
       "require": "./cjs/entries/browser.js"
+    },
+    "./entries/miniapp": {
+      "types": "./es/entries/miniapp.d.ts",
+      "import": "./es/entries/miniapp.js",
+      "require": "./cjs/entries/miniapp.js"
     },
     "./entries/runtime-installer": {
       "types": "./es/entries/runtime-installer.d.ts",

--- a/packages/vrender-kits/package.json
+++ b/packages/vrender-kits/package.json
@@ -178,6 +178,11 @@
       "import": "./es/installers/graphics-lite.js",
       "require": "./cjs/installers/graphics-lite.js"
     },
+    "./installers/lynx": {
+      "types": "./es/installers/lynx.d.ts",
+      "import": "./es/installers/lynx.js",
+      "require": "./cjs/installers/lynx.js"
+    },
     "./jsx/graphicType": {
       "types": "./es/jsx/graphicType.d.ts",
       "import": "./es/jsx/graphicType.js",

--- a/packages/vrender-kits/src/installers/app.ts
+++ b/packages/vrender-kits/src/installers/app.ts
@@ -60,7 +60,6 @@ import {
 import { bindBrowserCanvasModules } from '../canvas/contributions/browser/modules';
 import { bindFeishuCanvasModules } from '../canvas/contributions/feishu/modules';
 import { bindHarmonyCanvasModules } from '../canvas/contributions/harmony/modules';
-import { bindLynxCanvasModules } from '../canvas/contributions/lynx/modules';
 import { bindNodeCanvasModules } from '../canvas/contributions/node/modules';
 import { bindTaroCanvasModules } from '../canvas/contributions/taro/modules';
 import { bindTTCanvasModules } from '../canvas/contributions/tt/modules';
@@ -68,7 +67,6 @@ import { bindWxCanvasModules } from '../canvas/contributions/wx/modules';
 import { bindBrowserEnv } from '../env/browser';
 import { bindFeishuEnv } from '../env/feishu';
 import { bindHarmonyEnv } from '../env/harmony';
-import { bindLynxEnv } from '../env/lynx';
 import { bindNodeEnv } from '../env/node';
 import { bindTaroEnv } from '../env/taro';
 import { bindTTEnv } from '../env/tt';
@@ -100,7 +98,6 @@ import { bindGifImageRenderContribution } from '../render/contributions/canvas/g
 import { bindBrowserWindowContribution } from '../window/contributions/browser-contribution';
 import { bindFeishuWindowContribution } from '../window/contributions/feishu-contribution';
 import { bindHarmonyWindowContribution } from '../window/contributions/harmony-contribution';
-import { bindLynxWindowContribution } from '../window/contributions/lynx-contribution';
 import { bindNodeWindowContribution } from '../window/contributions/node-contribution';
 import { bindTaroWindowContribution } from '../window/contributions/taro-contribution';
 import { bindTTWindowContribution } from '../window/contributions/tt-contribution';
@@ -339,18 +336,7 @@ export function installWxEnvToApp(app: IApp, envParams?: IEnvParamsMap['wx']): v
   );
 }
 
-export function installLynxEnvToApp(app: IApp, envParams?: IEnvParamsMap['lynx']): void {
-  installRuntimeEnvToApp(
-    app,
-    'lynx',
-    {
-      bindEnv: bindLynxEnv,
-      bindCanvasModules: bindLynxCanvasModules,
-      bindWindowContribution: bindLynxWindowContribution
-    },
-    envParams
-  );
-}
+export { installLynxEnvToApp } from './lynx';
 
 export function installHarmonyEnvToApp(app: IApp, envParams?: IEnvParamsMap['harmony']): void {
   installRuntimeEnvToApp(

--- a/packages/vrender-kits/src/installers/lynx.ts
+++ b/packages/vrender-kits/src/installers/lynx.ts
@@ -1,0 +1,79 @@
+import {
+  configureRuntimeApplicationForApp,
+  getRuntimeInstallerBindingContext,
+  getRuntimeInstallerGlobal,
+  installRuntimePickersToApp,
+  refreshRuntimeInstallerContributions
+} from '@visactor/vrender-core/entries/runtime-installer';
+import type {
+  IApp,
+  IContributionProvider,
+  IEnvParamsMap,
+  IGraphicPicker,
+  IPickItemInterceptorContribution,
+  IPickServiceInterceptorContribution
+} from '@visactor/vrender-core';
+import { application } from '@visactor/vrender-core/application';
+import { PickItemInterceptor, PickServiceInterceptor } from '@visactor/vrender-core/picker/constants';
+import { bindLynxCanvasModules } from '../canvas/contributions/lynx/modules';
+import { bindLynxEnv } from '../env/lynx';
+import { loadMathPicker } from '../picker/math-module';
+import { DefaultMathPickerService } from '../picker/math-picker-service';
+import { MathPickerContribution } from '../picker/contributions/constants';
+import { bindLynxWindowContribution } from '../window/contributions/lynx-contribution';
+
+type RuntimeBindingContext = ReturnType<typeof getRuntimeInstallerBindingContext>;
+
+function createRegistryContributionProvider<T>(entries: () => T[]): IContributionProvider<T> {
+  return { getContributions: entries };
+}
+
+function createForcedEnvParams(envParams?: IEnvParamsMap['lynx']): IEnvParamsMap['lynx'] {
+  if (envParams != null && (typeof envParams === 'object' || typeof envParams === 'function')) {
+    const forcedEnvParams = Object.create(envParams as object);
+    forcedEnvParams.force = true;
+    return forcedEnvParams as IEnvParamsMap['lynx'];
+  }
+
+  return { force: true } as IEnvParamsMap['lynx'];
+}
+
+function configureMathPickerFactory(app: IApp): void {
+  const bindingContext = getRuntimeInstallerBindingContext();
+  const pickerContributions = createRegistryContributionProvider<IGraphicPicker>(
+    () => app.registry.picker.getAll() as IGraphicPicker[]
+  );
+  const pickItemInterceptors = createRegistryContributionProvider<IPickItemInterceptorContribution>(() =>
+    bindingContext.isBound(PickItemInterceptor)
+      ? (bindingContext.getAll(PickItemInterceptor) as IPickItemInterceptorContribution[])
+      : []
+  );
+  const pickServiceInterceptors = createRegistryContributionProvider<IPickServiceInterceptorContribution>(() =>
+    bindingContext.isBound(PickServiceInterceptor)
+      ? (bindingContext.getAll(PickServiceInterceptor) as IPickServiceInterceptorContribution[])
+      : []
+  );
+
+  application.pickerServiceFactory = () =>
+    new DefaultMathPickerService(pickerContributions, pickItemInterceptors, pickServiceInterceptors);
+}
+
+export function installLynxEnvToApp(app: IApp, envParams?: IEnvParamsMap['lynx']): void {
+  configureRuntimeApplicationForApp(app);
+  const bindingContext = getRuntimeInstallerBindingContext();
+
+  bindLynxEnv(bindingContext);
+  bindLynxCanvasModules(bindingContext);
+  bindLynxWindowContribution(bindingContext);
+  refreshRuntimeInstallerContributions();
+  getRuntimeInstallerGlobal().setEnv('lynx', createForcedEnvParams(envParams));
+}
+
+export function installLynxPickersToApp(app: IApp): void {
+  configureRuntimeApplicationForApp(app);
+  const bindingContext = getRuntimeInstallerBindingContext();
+
+  loadMathPicker(bindingContext);
+  installRuntimePickersToApp(app, MathPickerContribution);
+  configureMathPickerFactory(app);
+}

--- a/packages/vrender/__tests__/types/entries-typing.ts
+++ b/packages/vrender/__tests__/types/entries-typing.ts
@@ -10,6 +10,10 @@ import {
   acquireSharedVRenderApp as acquireBrowserConditionSharedVRenderApp,
   type TVRenderSharedBrowserAppHandle
 } from '../../src/entries/shared-browser';
+import {
+  acquireSharedVRenderApp as acquireLynxConditionSharedVRenderApp,
+  type TVRenderSharedLynxAppHandle
+} from '../../src/entries/shared-lynx';
 
 const browserFactory: (options?: IEntryOptions) => IApp = createBrowserVRenderApp;
 const nodeFactory: (options?: IEntryOptions) => IApp = createNodeVRenderApp;
@@ -17,10 +21,7 @@ const browserSharedHandle: TVRenderSharedAppHandle<'browser'> = acquireSharedVRe
 const positionalLynxSharedHandle: TVRenderSharedAppHandle<'lynx'> = acquireSharedVRenderApp(undefined, 'lynx');
 const browserConditionDefaultHandle: TVRenderSharedBrowserAppHandle<'browser'> =
   acquireBrowserConditionSharedVRenderApp();
-const browserConditionLynxHandle: TVRenderSharedBrowserAppHandle<'lynx'> = acquireBrowserConditionSharedVRenderApp(
-  undefined,
-  'lynx'
-);
+const lynxConditionHandle: TVRenderSharedLynxAppHandle = acquireLynxConditionSharedVRenderApp(undefined, 'lynx');
 const lynxSharedOptions: TVRenderSharedAppOptions<'lynx'> = {
   env: 'lynx',
   key: 'main',
@@ -34,5 +35,5 @@ void nodeFactory;
 void browserSharedHandle;
 void positionalLynxSharedHandle;
 void browserConditionDefaultHandle;
-void browserConditionLynxHandle;
+void lynxConditionHandle;
 void lynxSharedOptions;

--- a/packages/vrender/__tests__/unit/entries.test.ts
+++ b/packages/vrender/__tests__/unit/entries.test.ts
@@ -6,6 +6,7 @@ declare const require: any;
 export {};
 
 type BootstrapMockOptions = {
+  core?: Record<string, any>;
   installers?: Record<string, any>;
   loaders?: Record<string, any>;
   registers?: Record<string, any>;
@@ -52,6 +53,10 @@ function createEmptyLegacyBindingContext() {
 }
 
 function mockBootstrapSubpaths(options: BootstrapMockOptions = {}) {
+  jest.doMock('@visactor/vrender-core/entries/miniapp', () => ({
+    createMiniappApp: options.core?.createMiniappApp ?? jest.fn()
+  }));
+
   jest.doMock('@visactor/vrender-kits/installers/app', () => ({
     installBrowserEnvToApp: jest.fn(),
     installBrowserPickersToApp: jest.fn(),
@@ -66,6 +71,13 @@ function mockBootstrapSubpaths(options: BootstrapMockOptions = {}) {
     installTTEnvToApp: jest.fn(),
     installWxEnvToApp: jest.fn(),
     ...options.installers
+  }));
+  jest.doMock('@visactor/vrender-kits/installers/lynx', () => ({
+    installLynxEnvToApp: options.installers?.installLynxEnvToApp ?? jest.fn(),
+    installLynxPickersToApp: options.installers?.installLynxPickersToApp ?? jest.fn()
+  }));
+  jest.doMock('@visactor/vrender-kits/installers/graphics', () => ({
+    installStandardGraphicsToApp: options.installers?.installDefaultGraphicsToApp ?? jest.fn()
   }));
 
   jest.doMock('@visactor/vrender-kits/picker/contributions/constants', () => ({
@@ -366,9 +378,11 @@ describe('vrender app-scoped entries', () => {
           registerCustomAnimate: jest.fn()
         }));
         mockBootstrapSubpaths({
+          core: { createMiniappApp },
           installers: {
             installDefaultGraphicsToApp,
             installMathPickersToApp,
+            installLynxPickersToApp: installMathPickersToApp,
             [installName]: installEnv
           },
           loaders: {

--- a/packages/vrender/__tests__/unit/public-subpath-exports.test.ts
+++ b/packages/vrender/__tests__/unit/public-subpath-exports.test.ts
@@ -16,6 +16,7 @@ type ExpectedSubpath = {
   subpath: string;
   source: string;
   browserSource?: string;
+  lynxSource?: string;
 };
 
 const expectedExports: Record<string, ExpectedSubpath[]> = {
@@ -31,6 +32,7 @@ const expectedExports: Record<string, ExpectedSubpath[]> = {
     { subpath: './installers/browser-lite', source: 'src/installers/browser-lite.ts' },
     { subpath: './installers/graphics', source: 'src/installers/graphics.ts' },
     { subpath: './installers/graphics-lite', source: 'src/installers/graphics-lite.ts' },
+    { subpath: './installers/lynx', source: 'src/installers/lynx.ts' },
     { subpath: './tools/dynamicTexture/effect', source: 'src/tools/dynamicTexture/effect.ts' }
   ],
   'vrender-components': [
@@ -61,7 +63,12 @@ const expectedExports: Record<string, ExpectedSubpath[]> = {
   vrender: [
     { subpath: './entries/shared-browser', source: 'src/entries/shared-browser.ts' },
     { subpath: './entries/shared-browser-lite', source: 'src/entries/shared-browser-lite.ts' },
-    { subpath: './entries/shared', source: 'src/entries/shared.ts', browserSource: 'src/entries/shared-browser.ts' },
+    {
+      subpath: './entries/shared',
+      source: 'src/entries/shared.ts',
+      browserSource: 'src/entries/shared-browser.ts',
+      lynxSource: 'src/entries/shared-lynx.ts'
+    },
     { subpath: './entries/browser', source: 'src/entries/browser.ts' },
     { subpath: './entries/node', source: 'src/entries/node.ts' },
     { subpath: './entries/miniapp', source: 'src/entries/miniapp.ts' },
@@ -111,7 +118,7 @@ describe('published public subpath exports', () => {
     test(`${packageName} exposes stable narrow subpaths`, () => {
       const packageJson = readPackageJson(packageName);
 
-      subpaths.forEach(({ subpath, source, browserSource }) => {
+      subpaths.forEach(({ subpath, source, browserSource, lynxSource }) => {
         const entry = packageJson.exports?.[subpath];
         const expectedImport = `./es/${source.replace(/^src\//, '').replace(/\.ts$/, '.js')}`;
         const expectedRequire = `./cjs/${source.replace(/^src\//, '').replace(/\.ts$/, '.js')}`;
@@ -122,14 +129,37 @@ describe('published public subpath exports', () => {
         const expectedBrowserRequire = browserSource
           ? `./cjs/${browserSource.replace(/^src\//, '').replace(/\.ts$/, '.js')}`
           : undefined;
+        const expectedLynxImport = lynxSource
+          ? `./es/${lynxSource.replace(/^src\//, '').replace(/\.ts$/, '.js')}`
+          : undefined;
+        const expectedLynxRequire = lynxSource
+          ? `./cjs/${lynxSource.replace(/^src\//, '').replace(/\.ts$/, '.js')}`
+          : undefined;
 
         expect(fs.existsSync(path.join(packagesRoot, packageName, source))).toBe(true);
+        if (lynxSource) {
+          expect(fs.existsSync(path.join(packagesRoot, packageName, lynxSource))).toBe(true);
+        }
         if (browserSource) {
           expect(fs.existsSync(path.join(packagesRoot, packageName, browserSource))).toBe(true);
-          expect(Object.keys(entry)).toEqual(['types', 'browser', 'import', 'require']);
+          expect(Object.keys(entry)).toEqual([
+            'types',
+            ...(lynxSource ? ['lynx'] : []),
+            'browser',
+            'import',
+            'require'
+          ]);
         }
         expect(entry).toEqual({
           types: expectedTypes,
+          ...(lynxSource
+            ? {
+                lynx: {
+                  import: expectedLynxImport,
+                  require: expectedLynxRequire
+                }
+              }
+            : null),
           ...(browserSource
             ? {
                 browser: {

--- a/packages/vrender/__tests__/unit/shared-browser-entry.test.ts
+++ b/packages/vrender/__tests__/unit/shared-browser-entry.test.ts
@@ -5,7 +5,6 @@
 declare const require: any;
 export {};
 
-const emptyArray = (): never[] => [];
 const SHARED_APP_REGISTRY_KEY = Symbol.for('visactor.vrender.sharedAppRegistry');
 
 describe('browser-condition shared app entry', () => {
@@ -14,141 +13,45 @@ describe('browser-condition shared app entry', () => {
     delete (globalThis as any)[SHARED_APP_REGISTRY_KEY];
   });
 
-  test('routes an explicit lynx env to the Lynx app without initializing the browser environment', () => {
+  test('creates the default browser app without loading Lynx', () => {
     jest.isolateModules(() => {
-      const lynxApp = {
-        env: 'lynx',
-        release: jest.fn()
-      };
-      const createBrowserApp = jest.fn(() => {
-        throw new Error('the Lynx shared app must not initialize the browser environment');
-      });
-      const createLynxVRenderApp = jest.fn(() => lynxApp);
+      const browserApp = { env: 'browser', release: jest.fn() };
+      const createBrowserApp = jest.fn(() => browserApp);
+      const bootstrapVRenderSharedBrowserApp = jest.fn((app: unknown) => app);
+      const installPendingRuntimeContributionModulesToApp = jest.fn();
 
-      jest.doMock('@visactor/vrender-core/entries/browser', () => ({
-        BrowserEntry: class BrowserEntry {},
-        createBrowserApp
-      }));
-      jest.doMock('../../src/entries/miniapp', () => ({ createLynxVRenderApp }));
+      jest.doMock('@visactor/vrender-core/entries/browser', () => ({ createBrowserApp }));
+      jest.doMock('../../src/entries/bootstrap-browser', () => ({ bootstrapVRenderSharedBrowserApp }));
+      jest.doMock('../../src/entries/runtime-contribution', () => ({ installPendingRuntimeContributionModulesToApp }));
+      jest.doMock('../../src/entries/miniapp', () => {
+        throw new Error('shared-browser must not load the multi-environment miniapp entry');
+      });
 
       const { acquireSharedVRenderApp } = require('../../src/entries/shared-browser');
-      const handle = (acquireSharedVRenderApp as any)(undefined, 'lynx');
+      const handle = acquireSharedVRenderApp();
 
-      expect(handle.env).toBe('lynx');
-      expect(handle.app).toBe(lynxApp);
-      expect(createLynxVRenderApp).toHaveBeenCalledTimes(1);
-      expect(createBrowserApp).not.toHaveBeenCalled();
+      expect(handle.env).toBe('browser');
+      expect(handle.app).toBe(browserApp);
+      expect(createBrowserApp).toHaveBeenCalledWith({});
+      expect(bootstrapVRenderSharedBrowserApp).toHaveBeenCalledWith(browserApp, undefined);
+      expect(installPendingRuntimeContributionModulesToApp).toHaveBeenCalledWith(browserApp);
 
       handle.release();
     });
   });
 
-  test('keeps browser as the default and isolates browser and Lynx shared apps', () => {
+  test('fails clearly when a non-browser environment resolves the browser condition', () => {
     jest.isolateModules(() => {
-      const legacyBindingContextMock = { getAll: jest.fn(emptyArray) };
-      const browserApp = {
-        env: 'browser',
-        registry: {
-          renderer: { getAll: jest.fn(emptyArray), clear: jest.fn(), register: jest.fn() },
-          picker: { getAll: jest.fn(emptyArray), clear: jest.fn(), register: jest.fn() }
-        },
-        release: jest.fn()
-      };
-      const lynxApp = { env: 'lynx', release: jest.fn() };
-      const createBrowserApp = jest.fn(() => browserApp);
-      const createLynxVRenderApp = jest.fn(() => lynxApp);
-
-      jest.doMock('@visactor/vrender-core/entries/browser', () => ({
-        createBrowserApp
+      jest.doMock('@visactor/vrender-core/entries/browser', () => ({ createBrowserApp: jest.fn() }));
+      jest.doMock('../../src/entries/bootstrap-browser', () => ({ bootstrapVRenderSharedBrowserApp: jest.fn() }));
+      jest.doMock('../../src/entries/runtime-contribution', () => ({
+        installPendingRuntimeContributionModulesToApp: jest.fn()
       }));
-      jest.doMock('../../src/entries/miniapp', () => ({ createLynxVRenderApp }));
-      jest.doMock('@visactor/vrender-core/legacy/bootstrap', () => ({
-        getLegacyBindingContext: jest.fn(() => legacyBindingContextMock)
-      }));
-      jest.doMock('@visactor/vrender-core/render/symbol', () => ({
-        GraphicRender: 'GraphicRender'
-      }));
-      jest.doMock('@visactor/vrender-core/plugin/3d', () => ({
-        registerDirectionalLight: jest.fn(),
-        registerOrthoCamera: jest.fn(),
-        registerViewTransform3dPlugin: jest.fn()
-      }));
-      jest.doMock('@visactor/vrender-core/plugin/attribute', () => ({
-        registerHtmlAttributePlugin: jest.fn(),
-        registerReactAttributePlugin: jest.fn()
-      }));
-      jest.doMock('@visactor/vrender-core/plugin/flex-layout', () => ({
-        registerFlexLayoutPlugin: jest.fn()
-      }));
-      jest.doMock('@visactor/vrender-kits/installers/browser', () => ({
-        installBrowserEnvToApp: jest.fn(),
-        installBrowserPickersToApp: jest.fn()
-      }));
-      jest.doMock('@visactor/vrender-kits/installers/graphics', () => ({
-        installStandardGraphicsToApp: jest.fn()
-      }));
-      jest.doMock('@visactor/vrender-kits/picker/contributions/constants', () => ({
-        CanvasPickerContribution: 'CanvasPickerContribution'
-      }));
-      jest.doMock('@visactor/vrender-animate/register', () => ({
-        registerAnimate: jest.fn()
-      }));
-
-      const registerMocks = {
-        arc: 'registerArc',
-        arc3d: 'registerArc3d',
-        area: 'registerArea',
-        circle: 'registerCircle',
-        glyph: 'registerGlyph',
-        group: 'registerGroup',
-        image: 'registerImage',
-        line: 'registerLine',
-        path: 'registerPath',
-        polygon: 'registerPolygon',
-        pyramid3d: 'registerPyramid3d',
-        rect: 'registerRect',
-        rect3d: 'registerRect3d',
-        richtext: 'registerRichtext',
-        shadowRoot: 'registerShadowRoot',
-        star: 'registerStar',
-        symbol: 'registerSymbol',
-        text: 'registerText',
-        wraptext: 'registerWrapText'
-      };
-
-      Object.entries(registerMocks).forEach(([name, exportName]) => {
-        jest.doMock(`@visactor/vrender-kits/register/register-${name}`, () => ({
-          [exportName]: jest.fn()
-        }));
-      });
-
-      [
-        '@visactor/vrender-kits/env/node',
-        '@visactor/vrender-kits/env/wx',
-        '@visactor/vrender-kits/env/harmony',
-        '@visactor/vrender-kits/env/browser',
-        '@visactor/vrender-kits/register/register-gif',
-        '@visactor/vrender-animate/custom/register'
-      ].forEach(moduleName => {
-        jest.doMock(moduleName, () => {
-          throw new Error(`${moduleName} should not be loaded by shared-browser`);
-        });
-      });
+      jest.doMock('../../src/entries/miniapp', () => ({ createLynxVRenderApp: jest.fn() }));
 
       const { acquireSharedVRenderApp } = require('../../src/entries/shared-browser');
-      const browserHandle = acquireSharedVRenderApp();
-      const lynxHandle = (acquireSharedVRenderApp as any)(undefined, 'lynx');
 
-      expect(createBrowserApp).toHaveBeenCalledTimes(1);
-      expect(createBrowserApp).toHaveBeenCalledWith({});
-      expect(browserHandle.env).toBe('browser');
-      expect(browserHandle.app).toBe(browserApp);
-      expect(lynxHandle.env).toBe('lynx');
-      expect(lynxHandle.app).toBe(lynxApp);
-      expect(browserHandle.app).not.toBe(lynxHandle.app);
-
-      browserHandle.release();
-      lynxHandle.release();
+      expect(() => acquireSharedVRenderApp({ env: 'lynx' } as any)).toThrow(/browser condition/i);
     });
   });
 });

--- a/packages/vrender/__tests__/unit/shared-entry-environment-isolation.test.ts
+++ b/packages/vrender/__tests__/unit/shared-entry-environment-isolation.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ */
+
+declare const __dirname: string;
+declare const require: any;
+export {};
+
+const fs = require('fs');
+const path = require('path');
+
+const entriesRoot = path.resolve(__dirname, '../../src/entries');
+const kitsRoot = path.resolve(__dirname, '../../../vrender-kits/src');
+
+const readSources = (root: string, files: string[]) =>
+  files.map(file => fs.readFileSync(path.join(root, file), 'utf8')).join('\n');
+
+describe('conditional shared entry isolation', () => {
+  test('keeps the browser entry independent from Lynx and multi-environment bootstraps', () => {
+    const source = readSources(entriesRoot, ['shared-browser.ts', 'bootstrap-browser.ts']);
+
+    expect(source).not.toMatch(/from ['"]\.\/(?:miniapp|lynx|bootstrap|bootstrap-lynx)['"]/);
+  });
+
+  test('keeps the Lynx entry independent from the multi-environment bootstrap', () => {
+    const source = readSources(entriesRoot, ['shared-lynx.ts', 'lynx.ts', 'bootstrap-lynx.ts']);
+    const installerSource = readSources(kitsRoot, ['installers/lynx.ts']);
+
+    expect(source).not.toMatch(/from ['"]\.\/(?:miniapp|bootstrap)['"]/);
+    expect(source).not.toMatch(/@visactor\/vrender-kits\/installers\/app/);
+    expect(installerSource).not.toMatch(/\/(?:browser|feishu|harmony|node|taro|tt|wx)(?:\/|['"])/);
+  });
+});

--- a/packages/vrender/__tests__/unit/shared-lynx-entry.test.ts
+++ b/packages/vrender/__tests__/unit/shared-lynx-entry.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+
+declare const require: any;
+export {};
+
+const SHARED_APP_REGISTRY_KEY = Symbol.for('visactor.vrender.sharedAppRegistry');
+
+describe('Lynx-condition shared app entry', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete (globalThis as any)[SHARED_APP_REGISTRY_KEY];
+  });
+
+  test('creates and shares a Lynx app without loading another environment entry', () => {
+    jest.isolateModules(() => {
+      const release = jest.fn();
+      const lynxApp = { env: 'lynx', release };
+      const createLynxVRenderApp = jest.fn(() => lynxApp);
+
+      jest.doMock('../../src/entries/lynx', () => ({ createLynxVRenderApp }));
+
+      const { acquireSharedVRenderApp } = require('../../src/entries/shared-lynx');
+      const first = acquireSharedVRenderApp({ env: 'lynx', envParams: { pixelRatio: 2 } });
+      const second = acquireSharedVRenderApp({ env: 'lynx', envParams: { pixelRatio: 3 } });
+
+      expect(first.app).toBe(lynxApp);
+      expect(second.app).toBe(lynxApp);
+      expect(first.env).toBe('lynx');
+      expect(createLynxVRenderApp).toHaveBeenCalledTimes(1);
+      expect(createLynxVRenderApp).toHaveBeenCalledWith({ envParams: { pixelRatio: 2 } });
+
+      first.release();
+      expect(release).not.toHaveBeenCalled();
+      second.release();
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('defaults to Lynx for the Lynx build condition', () => {
+    jest.isolateModules(() => {
+      const lynxApp = { env: 'lynx', release: jest.fn() };
+      const createLynxVRenderApp = jest.fn(() => lynxApp);
+
+      jest.doMock('../../src/entries/lynx', () => ({ createLynxVRenderApp }));
+
+      const { acquireSharedVRenderApp } = require('../../src/entries/shared-lynx');
+      const handle = acquireSharedVRenderApp();
+
+      expect(handle.env).toBe('lynx');
+      expect(handle.app).toBe(lynxApp);
+      handle.release();
+    });
+  });
+});

--- a/packages/vrender/package.json
+++ b/packages/vrender/package.json
@@ -109,6 +109,10 @@
     },
     "./entries/shared": {
       "types": "./es/entries/shared.d.ts",
+      "lynx": {
+        "import": "./es/entries/shared-lynx.js",
+        "require": "./cjs/entries/shared-lynx.js"
+      },
       "browser": {
         "import": "./es/entries/shared-browser.js",
         "require": "./cjs/entries/shared-browser.js"

--- a/packages/vrender/src/entries/bootstrap-common.ts
+++ b/packages/vrender/src/entries/bootstrap-common.ts
@@ -65,9 +65,17 @@ const standardLegacyGraphicRegistrations = [
   registerStar
 ];
 
-export function registerStandardPipeline(): void {
+export function registerStandardPlugins(): void {
   pluginRegistrations.forEach(register => register());
+}
+
+export function registerStandardAnimation(): void {
   registerAnimate();
+}
+
+export function registerStandardPipeline(): void {
+  registerStandardPlugins();
+  registerStandardAnimation();
 }
 
 export function registerStandardLegacyGraphics(): void {

--- a/packages/vrender/src/entries/bootstrap-lynx.ts
+++ b/packages/vrender/src/entries/bootstrap-lynx.ts
@@ -1,0 +1,37 @@
+import type { IEnvParamsMap } from '@visactor/vrender-core';
+import { registerCustomAnimate } from '@visactor/vrender-animate/custom/register';
+import { loadLynxEnv } from '@visactor/vrender-kits/env/lynx';
+import { installStandardGraphicsToApp } from '@visactor/vrender-kits/installers/graphics';
+import { installLynxEnvToApp, installLynxPickersToApp } from '@visactor/vrender-kits/installers/lynx';
+import { MathPickerContribution } from '@visactor/vrender-kits/picker/contributions/constants';
+import { registerGifImage } from '@visactor/vrender-kits/register/register-gif';
+import {
+  ensureBootstrap,
+  registerStandardAnimation,
+  registerStandardLegacyGraphics,
+  registerStandardPlugins,
+  syncLegacyPickersToApp,
+  syncLegacyRenderersToApp,
+  type TBootstrapTarget
+} from './bootstrap-common';
+
+export function bootstrapVRenderLynxApp<TApp extends object>(app: TApp, envParams?: IEnvParamsMap['lynx']): TApp {
+  const target = app as TBootstrapTarget;
+
+  if (!ensureBootstrap(target, 'lynx')) {
+    return app;
+  }
+
+  installLynxEnvToApp(app as any, envParams);
+  installStandardGraphicsToApp(app as any);
+  installLynxPickersToApp(app as any);
+  loadLynxEnv();
+  registerStandardLegacyGraphics();
+  registerGifImage();
+  syncLegacyRenderersToApp(app as any);
+  syncLegacyPickersToApp(app as any, MathPickerContribution);
+  registerStandardPlugins();
+  registerCustomAnimate();
+  registerStandardAnimation();
+  return app;
+}

--- a/packages/vrender/src/entries/lynx.ts
+++ b/packages/vrender/src/entries/lynx.ts
@@ -1,0 +1,16 @@
+import type { IApp, IEntryOptions, IEnvParamsMap } from '@visactor/vrender-core';
+import { createMiniappApp } from '@visactor/vrender-core/entries/miniapp';
+import { bootstrapVRenderLynxApp } from './bootstrap-lynx';
+import { installPendingRuntimeContributionModulesToApp } from './runtime-contribution';
+
+export type TVRenderLynxAppEntryOptions = IEntryOptions & {
+  envParams?: IEnvParamsMap['lynx'];
+};
+
+export function createLynxVRenderApp(options: TVRenderLynxAppEntryOptions = {}): IApp {
+  const { envParams, ...entryOptions } = options;
+  const app = bootstrapVRenderLynxApp(createMiniappApp(entryOptions) as IApp, envParams);
+
+  installPendingRuntimeContributionModulesToApp(app);
+  return app;
+}

--- a/packages/vrender/src/entries/miniapp.ts
+++ b/packages/vrender/src/entries/miniapp.ts
@@ -40,10 +40,8 @@ export function createWxVRenderApp(options: TVRenderMiniAppEntryOptions<'wx'> = 
   return createMiniEnvVRenderApp('wx', options);
 }
 
-export function createLynxVRenderApp(options: TVRenderMiniAppEntryOptions<'lynx'> = {}): IApp {
-  return createMiniEnvVRenderApp('lynx', options);
-}
-
 export function createHarmonyVRenderApp(options: TVRenderMiniAppEntryOptions<'harmony'> = {}): IApp {
   return createMiniEnvVRenderApp('harmony', options);
 }
+
+export { createLynxVRenderApp } from './lynx';

--- a/packages/vrender/src/entries/shared-browser.ts
+++ b/packages/vrender/src/entries/shared-browser.ts
@@ -1,7 +1,6 @@
 import type { IApp, IEntryOptions, IEnvParamsMap } from '@visactor/vrender-core';
 import { createBrowserApp } from '@visactor/vrender-core/entries/browser';
 import { bootstrapVRenderSharedBrowserApp } from './bootstrap-browser';
-import { createLynxVRenderApp } from './miniapp';
 import { installPendingRuntimeContributionModulesToApp } from './runtime-contribution';
 import {
   acquireSharedApp,
@@ -11,7 +10,9 @@ import {
   type TVRenderSharedAppKey
 } from './shared-registry';
 
-export type TVRenderSharedBrowserAppEnv = 'browser' | 'lynx';
+const SHARED_BROWSER_REGISTRY_ENV = 'browser-shared';
+
+export type TVRenderSharedBrowserAppEnv = 'browser';
 
 export type TVRenderSharedBrowserAppOptions<TEnv extends TVRenderSharedBrowserAppEnv = 'browser'> = IEntryOptions & {
   env?: TEnv;
@@ -26,25 +27,27 @@ export type TVRenderSharedBrowserAppOptions<TEnv extends TVRenderSharedBrowserAp
 export type TVRenderSharedBrowserAppHandle<TEnv extends TVRenderSharedBrowserAppEnv = 'browser'> =
   TVRenderSharedAppHandle<TEnv>;
 
-type TVRenderSharedBrowserAppArgument =
-  | TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv>
-  | IEnvParamsMap[TVRenderSharedBrowserAppEnv];
+type TVRenderSharedBrowserAppArgument = TVRenderSharedBrowserAppOptions | IEnvParamsMap['browser'];
 
 function isSharedBrowserAppOptions(
   options: TVRenderSharedBrowserAppArgument
-): options is TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv> {
+): options is TVRenderSharedBrowserAppOptions {
   return 'context' in options || 'env' in options || 'envParams' in options || 'key' in options;
+}
+
+function assertBrowserEnv(env: unknown): asserts env is 'browser' | undefined {
+  if (env !== undefined && env !== 'browser') {
+    throw new Error(`The browser condition only supports env "browser"; received "${String(env)}".`);
+  }
 }
 
 function resolveSharedBrowserAppOptions(
   optionsOrEnvParams?: TVRenderSharedBrowserAppArgument,
-  env?: TVRenderSharedBrowserAppEnv
-): TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv> {
+  env?: 'browser'
+): TVRenderSharedBrowserAppOptions {
+  assertBrowserEnv(env);
   if (env !== undefined) {
-    return {
-      env,
-      envParams: optionsOrEnvParams as IEnvParamsMap[TVRenderSharedBrowserAppEnv] | undefined
-    };
+    return { env, envParams: optionsOrEnvParams as IEnvParamsMap['browser'] | undefined };
   }
 
   if (optionsOrEnvParams === undefined) {
@@ -52,77 +55,51 @@ function resolveSharedBrowserAppOptions(
   }
 
   if (isSharedBrowserAppOptions(optionsOrEnvParams)) {
-    return {
-      ...optionsOrEnvParams,
-      env: optionsOrEnvParams.env ?? 'browser'
-    };
+    assertBrowserEnv((optionsOrEnvParams as { env?: unknown }).env);
+    return { ...optionsOrEnvParams, env: 'browser' };
   }
 
-  return {
-    env: 'browser',
-    envParams: optionsOrEnvParams
-  };
+  return { env: 'browser', envParams: optionsOrEnvParams };
 }
 
-function createSharedBrowserApp(options: TVRenderSharedBrowserAppOptions<TVRenderSharedBrowserAppEnv>): IApp {
-  const { env, envParams } = options;
+function createSharedBrowserApp(options: TVRenderSharedBrowserAppOptions): IApp {
+  const { envParams } = options;
   const entryOptions = { ...options };
   delete entryOptions.env;
   delete entryOptions.envParams;
   delete entryOptions.key;
 
-  if (env === 'lynx') {
-    return createLynxVRenderApp({
-      ...(entryOptions as IEntryOptions),
-      envParams: envParams as IEnvParamsMap['lynx']
-    });
-  }
-
-  const app = bootstrapVRenderSharedBrowserApp(
-    createBrowserApp(entryOptions as any) as unknown as IApp,
-    envParams as IEnvParamsMap['browser']
-  );
+  const app = bootstrapVRenderSharedBrowserApp(createBrowserApp(entryOptions as any) as unknown as IApp, envParams);
 
   installPendingRuntimeContributionModulesToApp(app);
   return app;
 }
 
 export function acquireSharedBrowserVRenderApp(
-  options?: TVRenderSharedBrowserAppOptions<'browser'>
-): TVRenderSharedBrowserAppHandle<'browser'>;
+  options?: TVRenderSharedBrowserAppOptions
+): TVRenderSharedBrowserAppHandle;
 export function acquireSharedBrowserVRenderApp(
   envParams?: IEnvParamsMap['browser'],
   env?: 'browser'
-): TVRenderSharedBrowserAppHandle<'browser'>;
+): TVRenderSharedBrowserAppHandle;
 export function acquireSharedBrowserVRenderApp(
-  optionsOrEnvParams?: TVRenderSharedBrowserAppOptions<'browser'> | IEnvParamsMap['browser'],
+  optionsOrEnvParams?: TVRenderSharedBrowserAppArgument,
   env?: 'browser'
-): TVRenderSharedBrowserAppHandle<'browser'> {
-  const options = resolveSharedBrowserAppOptions(optionsOrEnvParams, env) as TVRenderSharedBrowserAppOptions<'browser'>;
-  return acquireSharedApp('browser-shared', options, createSharedBrowserApp, 'browser');
+): TVRenderSharedBrowserAppHandle {
+  const options = resolveSharedBrowserAppOptions(optionsOrEnvParams, env);
+  return acquireSharedApp(SHARED_BROWSER_REGISTRY_ENV, options, createSharedBrowserApp, 'browser');
 }
 
 export function getSharedBrowserVRenderApp(key?: TVRenderSharedAppKey): IApp | null {
-  return getSharedApp('browser-shared', key);
+  return getSharedApp(SHARED_BROWSER_REGISTRY_ENV, key);
 }
 
 export function releaseSharedBrowserVRenderApp(key?: TVRenderSharedAppKey): void {
-  releaseSharedApp('browser-shared', key);
+  releaseSharedApp(SHARED_BROWSER_REGISTRY_ENV, key);
 }
 
-export function acquireSharedVRenderApp<TEnv extends TVRenderSharedBrowserAppEnv>(
-  options?: TVRenderSharedBrowserAppOptions<TEnv>
-): TVRenderSharedBrowserAppHandle<TEnv>;
-export function acquireSharedVRenderApp<TEnv extends TVRenderSharedBrowserAppEnv>(
-  envParams?: IEnvParamsMap[TEnv],
-  env?: TEnv
-): TVRenderSharedBrowserAppHandle<TEnv>;
-export function acquireSharedVRenderApp(
-  optionsOrEnvParams?: TVRenderSharedBrowserAppArgument,
-  env?: TVRenderSharedBrowserAppEnv
-): TVRenderSharedBrowserAppHandle<TVRenderSharedBrowserAppEnv> {
-  const options = resolveSharedBrowserAppOptions(optionsOrEnvParams, env);
-  return acquireSharedApp(`${options.env}-shared`, options, createSharedBrowserApp, options.env);
-}
-
-export { getSharedBrowserVRenderApp as getSharedVRenderApp, releaseSharedBrowserVRenderApp as releaseSharedVRenderApp };
+export {
+  acquireSharedBrowserVRenderApp as acquireSharedVRenderApp,
+  getSharedBrowserVRenderApp as getSharedVRenderApp,
+  releaseSharedBrowserVRenderApp as releaseSharedVRenderApp
+};

--- a/packages/vrender/src/entries/shared-lynx.ts
+++ b/packages/vrender/src/entries/shared-lynx.ts
@@ -1,0 +1,92 @@
+import type { IApp, IEntryOptions, IEnvParamsMap } from '@visactor/vrender-core';
+import { createLynxVRenderApp } from './lynx';
+import {
+  acquireSharedApp,
+  getSharedApp,
+  releaseSharedApp,
+  type TVRenderSharedAppHandle,
+  type TVRenderSharedAppKey
+} from './shared-registry';
+
+const SHARED_LYNX_REGISTRY_ENV = 'lynx-shared';
+
+export type TVRenderSharedLynxAppOptions = IEntryOptions & {
+  env?: 'lynx';
+  envParams?: IEnvParamsMap['lynx'];
+  /**
+   * Shared identity inside the current JS runtime. Use a stable app/page/container key
+   * when multiple products, such as VChart and VTable, should share one VRender app.
+   */
+  key?: TVRenderSharedAppKey;
+};
+
+export type TVRenderSharedLynxAppHandle = TVRenderSharedAppHandle<'lynx'>;
+
+type TVRenderSharedLynxAppArgument = TVRenderSharedLynxAppOptions | IEnvParamsMap['lynx'];
+
+function isSharedLynxAppOptions(options: TVRenderSharedLynxAppArgument): options is TVRenderSharedLynxAppOptions {
+  return 'context' in options || 'env' in options || 'envParams' in options || 'key' in options;
+}
+
+function assertLynxEnv(env: unknown): asserts env is 'lynx' | undefined {
+  if (env !== undefined && env !== 'lynx') {
+    throw new Error(`The Lynx condition only supports env "lynx"; received "${String(env)}".`);
+  }
+}
+
+function resolveSharedLynxAppOptions(
+  optionsOrEnvParams?: TVRenderSharedLynxAppArgument,
+  env?: 'lynx'
+): TVRenderSharedLynxAppOptions {
+  assertLynxEnv(env);
+  if (env !== undefined) {
+    return { env, envParams: optionsOrEnvParams as IEnvParamsMap['lynx'] | undefined };
+  }
+
+  if (optionsOrEnvParams === undefined) {
+    return { env: 'lynx' };
+  }
+
+  if (isSharedLynxAppOptions(optionsOrEnvParams)) {
+    assertLynxEnv((optionsOrEnvParams as { env?: unknown }).env);
+    return { ...optionsOrEnvParams, env: 'lynx' };
+  }
+
+  return { env: 'lynx', envParams: optionsOrEnvParams };
+}
+
+function createSharedLynxApp(options: TVRenderSharedLynxAppOptions): IApp {
+  const { envParams } = options;
+  const entryOptions = { ...options };
+  delete entryOptions.env;
+  delete entryOptions.envParams;
+  delete entryOptions.key;
+  return createLynxVRenderApp({ ...entryOptions, envParams });
+}
+
+export function acquireSharedLynxVRenderApp(options?: TVRenderSharedLynxAppOptions): TVRenderSharedLynxAppHandle;
+export function acquireSharedLynxVRenderApp(
+  envParams?: IEnvParamsMap['lynx'],
+  env?: 'lynx'
+): TVRenderSharedLynxAppHandle;
+export function acquireSharedLynxVRenderApp(
+  optionsOrEnvParams?: TVRenderSharedLynxAppArgument,
+  env?: 'lynx'
+): TVRenderSharedLynxAppHandle {
+  const options = resolveSharedLynxAppOptions(optionsOrEnvParams, env);
+  return acquireSharedApp(SHARED_LYNX_REGISTRY_ENV, options, createSharedLynxApp, 'lynx');
+}
+
+export function getSharedLynxVRenderApp(key?: TVRenderSharedAppKey): IApp | null {
+  return getSharedApp(SHARED_LYNX_REGISTRY_ENV, key);
+}
+
+export function releaseSharedLynxVRenderApp(key?: TVRenderSharedAppKey): void {
+  releaseSharedApp(SHARED_LYNX_REGISTRY_ENV, key);
+}
+
+export {
+  acquireSharedLynxVRenderApp as acquireSharedVRenderApp,
+  getSharedLynxVRenderApp as getSharedVRenderApp,
+  releaseSharedLynxVRenderApp as releaseSharedVRenderApp
+};


### PR DESCRIPTION
## 修改内容

- 为 `@visactor/vrender/entries/shared` 增加独立的 Browser 与 Lynx 条件入口
- 避免 Browser 构建静态引入 Lynx 及其他 miniapp 环境实现
- 保持 VChart 与 Lynx 使用方式不变

## 验证

- VRender 发布包全量测试通过
- Browser 条件仅解析 Browser 入口
- Lynx 条件仅解析 Lynx 入口
- VChart Lynx 兼容测试 7/7 通过
- `1.1.10-alpha.0` 用户测试正常